### PR TITLE
Fixes SVG image aspect ratio

### DIFF
--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -15,7 +15,6 @@ class StataParser(argparse.ArgumentParser):
         sys.exit(1)
 
     def error(self, msg):
-        print("debug1")
         print_kernel('error: %s\n' % msg, self.kernel)
         print_kernel(self.format_usage(), self.kernel)
         sys.exit(2)
@@ -205,8 +204,11 @@ class StataMagics():
 
         cm = CodeManager("macro dir")
         rc, imgs, res = kernel.stata.do(cm.get_chunks(), self)
-        stata_globals = gregex['main'].findall(res)
+        if rc:
+            self.status = -1
+            return code
 
+        stata_globals = gregex['main'].findall(res)
         lens = 0
         find_name = gregex['match'] != ''
         print_globals = []

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -191,7 +191,7 @@ class StataSession(object):
         if self.execution_mode == 'console':
             log = []
             rc = 0
-            err_regex = re.compile(r'\r\nr\((\d+)\);\r\n').search
+            err_regex = re.compile(r'\r\nr\((\d+)\);($|\r\n)').search
             new_syn_chunks = []
             imgs = []
 
@@ -718,7 +718,21 @@ class StataSession(object):
         parsed = minidom.parseString(img.encode('utf-8'))
         (svg, ) = parsed.getElementsByTagName('svg')
 
+        # Fix the viewbox so programs can set the correct aspect ratio
+        x1, y1, x2, y2 = svg.getAttribute("viewBox").split(' ')
+        width, height = int(width), int(height)
+        view_width = int(x2)
+        view_height = int(y2)
+        view_ratio = view_width / view_height
+        new_ratio = width / height
+        if width > height:
+            view_height = int(view_height * view_ratio / new_ratio)
+        else:
+            view_width = int(view_width * new_ratio / view_ratio)
+
         # Handle overrides in case they were not encoded.
+        view = (0, 0, view_width, view_height)
+        svg.setAttribute('viewBox', '%d %d %d %d' % view)
         svg.setAttribute('width', '%dpx' % width)
         svg.setAttribute('height', '%dpx' % height)
 


### PR DESCRIPTION
Fix the viewbox in SVG images when setting width and height so programs can set the correct aspect ratio. It also modifies the error regex to `r'\r\nr\((\d+)\);($|\r\n)'` because at least on my system Stata doesn't send the second line break; the string just ends.

- [X] closes #62 
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry