### PR TITLE
Support #delimit;

### DIFF
--- a/stata_kernel/kernel.py
+++ b/stata_kernel/kernel.py
@@ -22,6 +22,7 @@ class StataKernel(Kernel):
         self.graphs = {}
         self.magics = StataMagics()
 
+        self.sc_delimit_mode = False
         self.stata = StataSession()
         self.banner = self.stata.banner
 
@@ -55,7 +56,9 @@ class StataKernel(Kernel):
             return self.magics.quit_early
 
         # Tokenize code and return code chunks
-        cm = CodeManager(code)
+        cm = CodeManager(code, self.sc_delimit_mode)
+        self.sc_delimit_mode = cm.ends_sc
+
         rc, imgs, res = self.stata.do(cm.get_chunks(), self.magics)
         stream_content = {'text': res}
 
@@ -137,7 +140,7 @@ class StataKernel(Kernel):
         return {}
 
     def is_complete(self, code):
-        cm = CodeManager(code)
-        if str(cm.tokens[-1][0]) == 'Token.MatchingBracket.Other':
+        cm = CodeManager(code, self.sc_delimit_mode)
+        if str(cm.tokens_nocomments[-1][0]) == 'Token.MatchingBracket.Other':
             return False
         return True

--- a/stata_kernel/stata_lexer.py
+++ b/stata_kernel/stata_lexer.py
@@ -119,8 +119,10 @@ class StataLexer(RegexLexer):
             (r';', Token.Keyword.Reserved),
             (r'.', Token.Keyword.Namespace),
         ],
+        # Made changes for //, // inside of *, and ending character for *
         'delimit;-comments': [
-            (r'(^//|(?<=\s)//)(?!/)', Comment.Single, 'delimit;-comments-double-slash'),
+            # Either after a ; delimiter or has whitespace after beginning of the line
+            (r'((^\s+//)|(?<=;\s)\s*//)(?!/)', Comment.Single, 'delimit;-comments-double-slash'),
             (r'^\s*\*', Comment.Single, 'delimit;-comments-star'),
             (r'/\*', Comment.Multiline, 'delimit;-comments-block'),
             (r'(^///|(?<=\s)///)', Comment.Special, 'delimit;-comments-triple-slash')
@@ -137,10 +139,9 @@ class StataLexer(RegexLexer):
         'delimit;-comments-star': [
             (r'///.*?\n', Comment.Single,
                 ('#pop', 'delimit;-comments-triple-slash')),
-            (r'(^//|(?<=\s)//)(?!/)', Comment.Single,
-                ('#pop', 'delimit;-comments-double-slash')),
+            # // doesn't break out of star comment inside #delimit ;
             (r'/\*', Comment.Multiline, 'delimit;-comments-block'),
-            # Only #delimit; change I made so far:
+            # ; ends a * comment
             (r'.(?=;)', Comment.Single, '#pop'),
             (r'.', Comment.Single),
         ],

--- a/stata_kernel/stata_lexer.py
+++ b/stata_kernel/stata_lexer.py
@@ -8,17 +8,29 @@ class StataLexer(RegexLexer):
     """Modified Pygments Stata Lexer
 
     I only need accurate handling of comment, string, and line-continuation
-    environments
+    environments.
+
+    When in #delimit ; mode, always add #delimit ; to the first line, then run
+    through this same lexer.
+
+    I have to use the Pygments token types, which don't really let me express what I want to express.
+
+    Make a `delimiter` type. Then mark `\\n` and `;` as the delimiter in the respective zones. Then I can use the standard Text or Block keywords in both places. Take out any \\n from Token.Text first, because that's a newline in the ;-delimited block.
+
+    For #delimit; text, do two passes, once to remove comments. Then take out ; and extra text \\n and put in delimiting \\n. Then put through once more to find blocks.
+
+    Text: Arbitrary text
+    Token.Keyword.Reserved: Delimiter (either \\n or ;), depending on the block
     """
     flags = re.MULTILINE | re.DOTALL
     tokens = {
         'root': [
-            # Later, add include('#delimit;') here
             include('comments'),
             include('strings'),
             (r'^[^\n]*?\{', Token.MatchingBracket.Other, 'block'),
             (r'^\s*(pr(ogram|ogra|ogr|og|o)?)\s+(?!di|dr|l)(de(fine|fin|fi|f)?\s+)?', Token.MatchingBracket.Other, 'program'),
             (r'^\s*inp(u|ut)?', Token.MatchingBracket.Other, 'program'),
+            (r'^\s*#d(e|el|eli|elim|elimi|elimit)?\s*;\s*\n', Comment.Single, 'delimit;'),
             (r'.', Text),
         ],
         'block': [
@@ -49,7 +61,6 @@ class StataLexer(RegexLexer):
             (r'(^//|(?<=\s)//)(?!/)', Comment.Single,
                 ('#pop', 'comments-double-slash')),
             (r'/\*', Comment.Multiline, 'comments-block'),
-            # include('comments'),
             (r'.(?=\n)', Comment.Single, '#pop'),
             (r'.', Comment.Single),
         ],
@@ -98,6 +109,66 @@ class StataLexer(RegexLexer):
         'string-regular-inside-blocks': [
             (r'(")(?!\')|(?=\n)', Token.MatchingBracket.Other, '#pop'),
             (r'.', Token.MatchingBracket.Other)
-        ]
+        ],
+
+
+        'delimit;': [
+            (r'^\s*#d(e|el|eli|elim|elimi|elimit)?\s+cr\s*\n', Comment.Single, '#pop'),
+            include('delimit;-comments'),
+            include('delimit;-strings'),
+            (r';', Token.Keyword.Reserved),
+            (r'.', Token.Keyword.Namespace),
+        ],
+        'delimit;-comments': [
+            (r'(^//|(?<=\s)//)(?!/)', Comment.Single, 'delimit;-comments-double-slash'),
+            (r'^\s*\*', Comment.Single, 'delimit;-comments-star'),
+            (r'/\*', Comment.Multiline, 'delimit;-comments-block'),
+            (r'(^///|(?<=\s)///)', Comment.Special, 'delimit;-comments-triple-slash')
+        ],
+        'delimit;-comments-block': [
+            (r'/\*', Comment.Multiline, '#push'),
+            # this ends and restarts a comment block. but need to catch this so
+            # that it doesn\'t start _another_ level of comment blocks
+            (r'\*/\*', Comment.Multiline),
+            (r'(\*/\s+\*(?!/)[^\n]*)|(\*/)', Comment.Multiline, '#pop'),
+            # Match anything else as a character inside the comment
+            (r'.', Comment.Multiline),
+        ],
+        'delimit;-comments-star': [
+            (r'///.*?\n', Comment.Single,
+                ('#pop', 'delimit;-comments-triple-slash')),
+            (r'(^//|(?<=\s)//)(?!/)', Comment.Single,
+                ('#pop', 'delimit;-comments-double-slash')),
+            (r'/\*', Comment.Multiline, 'delimit;-comments-block'),
+            # Only #delimit; change I made so far:
+            (r'.(?=;)', Comment.Single, '#pop'),
+            (r'.', Comment.Single),
+        ],
+        'delimit;-comments-triple-slash': [
+            (r'\n', Comment.Special, '#pop'),
+            # A // breaks out of a comment for the rest of the line
+            (r'//.*?(?=\n)', Comment.Single, '#pop'),
+            (r'.', Comment.Special),
+        ],
+        'delimit;-comments-double-slash': [
+            (r'\n', Token.Keyword.Namespace, '#pop'),
+            (r'.', Comment.Single),
+        ],
+        'delimit;-strings': [
+            # `"compound string"'
+            (r'`"', Token.Keyword.Namespace, 'delimit;-string-compound'),
+            # "string"
+            (r'(?<!`)"', Token.Keyword.Namespace, 'delimit;-string-regular'),
+        ],
+        'delimit;-string-compound': [
+            (r'`"', Token.Keyword.Namespace, '#push'),
+            (r'"\'', Token.Keyword.Namespace, '#pop'),
+            (r'.', Token.Keyword.Namespace)
+        ],
+        'delimit;-string-regular': [
+            (r'(")(?!\')|(?=\n)', Token.Keyword.Namespace, '#pop'),
+            (r'.', Token.Keyword.Namespace)
+        ],
+
     }
 # yapf: enable

--- a/stata_kernel/stata_lexer.py
+++ b/stata_kernel/stata_lexer.py
@@ -30,7 +30,7 @@ class StataLexer(RegexLexer):
             (r'^[^\n]*?\{', Token.MatchingBracket.Other, 'block'),
             (r'^\s*(pr(ogram|ogra|ogr|og|o)?)\s+(?!di|dr|l)(de(fine|fin|fi|f)?\s+)?', Token.MatchingBracket.Other, 'program'),
             (r'^\s*inp(u|ut)?', Token.MatchingBracket.Other, 'program'),
-            (r'^\s*#d(e|el|eli|elim|elimi|elimit)?\s*;\s*\n', Comment.Single, 'delimit;'),
+            (r'^\s*#d(e|el|eli|elim|elimi|elimit)?\s*;\s*?$', Comment.Single, 'delimit;'),
             (r'.', Text),
         ],
         'block': [
@@ -113,7 +113,7 @@ class StataLexer(RegexLexer):
 
 
         'delimit;': [
-            (r'^\s*#d(e|el|eli|elim|elimi|elimit)?\s+cr\s*\n', Comment.Single, '#pop'),
+            (r'^\s*#d(e|el|eli|elim|elimi|elimit)?\s+cr\s*?$', Comment.Single, '#pop'),
             include('delimit;-comments'),
             include('delimit;-strings'),
             (r';', Token.Keyword.Reserved),

--- a/tests/test_stata_lexer.py
+++ b/tests/test_stata_lexer.py
@@ -462,7 +462,8 @@ class TestSemicolonDelimitComments(object):
         code = '#delimit ;\n// a\na;'
         tokens = get_tokens(code)
         expected = [
-            (Token.Comment.Single, '#delimit ;\n'),
+            (Token.Comment.Single, '#delimit ;'),
+            (Token.Keyword.Namespace, '\n'),
             (Token.Comment.Single, '//'),
             (Token.Comment.Single, ' '),
             (Token.Comment.Single, 'a'),
@@ -483,7 +484,8 @@ class TestSemicolonDelimitComments(object):
         code = '#delimit ;\n// /* a\na;'
         tokens = get_tokens(code)
         expected = [
-            (Token.Comment.Single, '#delimit ;\n'),
+            (Token.Comment.Single, '#delimit ;'),
+            (Token.Keyword.Namespace, '\n'),
             (Token.Comment.Single, '//'),
             (Token.Comment.Single, ' '),
             (Token.Comment.Single, '/'),
@@ -507,7 +509,8 @@ class TestSemicolonDelimitComments(object):
         code = '#delimit ;\n* a\na;'
         tokens = get_tokens(code)
         expected = [
-            (Token.Comment.Single, '#delimit ;\n'),
+            (Token.Comment.Single, '#delimit ;'),
+            (Token.Keyword.Namespace, '\n'),
             (Token.Comment.Single, '*'),
             (Token.Comment.Single, ' '),
             (Token.Comment.Single, 'a'),
@@ -528,7 +531,8 @@ class TestSemicolonDelimitComments(object):
         code = '#delimit ;\n* /* a\na;'
         tokens = get_tokens(code)
         expected = [
-            (Token.Comment.Single, '#delimit ;\n'),
+            (Token.Comment.Single, '#delimit ;'),
+            (Token.Keyword.Namespace, '\n'),
             (Token.Comment.Single, '*'),
             (Token.Comment.Single, ' '),
             (Token.Comment.Multiline, '/*'),
@@ -552,7 +556,8 @@ class TestSemicolonDelimitComments(object):
         code = '#delimit ;\n* // a\na;'
         tokens = get_tokens(code)
         expected = [
-            (Token.Comment.Single, '#delimit ;\n'),
+            (Token.Comment.Single, '#delimit ;'),
+            (Token.Keyword.Namespace, '\n'),
             (Token.Comment.Single, '*'),
             (Token.Comment.Single, ' '),
             (Token.Comment.Single, '/'),
@@ -577,7 +582,8 @@ class TestSemicolonDelimitComments(object):
         code = '#delimit ;\na\n // c\na;'
         tokens = get_tokens(code)
         expected = [
-            (Token.Comment.Single, '#delimit ;\n'),
+            (Token.Comment.Single, '#delimit ;'),
+            (Token.Keyword.Namespace, '\n'),
             (Token.Keyword.Namespace, 'a'),
             (Token.Keyword.Namespace, '\n'),
             (Token.Comment.Single, ' //'),
@@ -601,7 +607,8 @@ class TestSemicolonDelimitComments(object):
         code = '#delimit ;\na\n// c\na;'
         tokens = get_tokens(code)
         expected = [
-            (Token.Comment.Single, '#delimit ;\n'),
+            (Token.Comment.Single, '#delimit ;'),
+            (Token.Keyword.Namespace, '\n'),
             (Token.Keyword.Namespace, 'a'),
             (Token.Keyword.Namespace, '\n'),
             (Token.Keyword.Namespace, '/'),


### PR DESCRIPTION
- [x] closes #37 
- [x] tests added / passed (will be done)

This PR 
- Updates the lexer to understand ;
- Tries to support edge cases according to [Statalist](https://www.statalist.org/forums/forum/general-stata-discussion/general/1448244-understanding-stata-s-comment-hierarchy). Tests forthcoming. The only thing it seemed I had to change was to prevent `\n` from ending the `*` comment, and to make it end with `;` instead.
- Inside `CodeManager`, if it sees there are chunks that use `#delimit;`, it removes the text newlines, substitutes `\n` for `;` and then runs it through the lexer once more to get blocks, i.e. `foreach` and `program`.

Issues still:
- [x] Sending just `#delimit ;` crashes stata because I apparently still send something?
- [x] Store #delimit state in the kernel class. This way someone can use #delimit; in one block and not need to copy it to every block.