### PR TITLE
Some #delimit fixes

### DIFF
--- a/stata_kernel/code_manager.py
+++ b/stata_kernel/code_manager.py
@@ -20,10 +20,10 @@ class CodeManager(object):
 
         self.has_sc_delimits = 'Token.Keyword.Namespace' in [
             str(x[0]) for x in self.tokens_nocomments]
-        self.is_complete = self._is_complete()
-
         if self.has_sc_delimits:
             self.adjust_for_semicolons()
+
+        self.is_complete = self._is_complete()
 
     def tokenize_code(self, code):
         """Tokenize input code using custom lexer

--- a/stata_kernel/code_manager.py
+++ b/stata_kernel/code_manager.py
@@ -9,9 +9,9 @@ class CodeManager(object):
     """
 
     def __init__(self, code, semicolon_delimit=False):
+        self.input = code
         if semicolon_delimit:
             code = '#delimit ;\n' + code
-        self.input = code
         self.tokens = self.tokenize_code(code)
         self.tokens_nocomments = self.remove_comments()
 
@@ -87,7 +87,15 @@ class CodeManager(object):
           `di 2 + ///` or `di 2 + /*`.
         - If in a #delimit ; block and there are non-whitespace characters after
           the last semicolon.
+
+        Special case for code to be complete:
+        - %magics
         """
+
+        magic_regex = re.compile(
+            r'\A%(?P<magic>.+?)(?P<code>\s+.*)?\Z', flags=re.DOTALL + re.MULTILINE)
+        if magic_regex.search(self.input):
+            return True
 
         # block constructs
         if str(self.tokens_nocomments[-1][0]) == 'Token.MatchingBracket.Other':

--- a/stata_kernel/code_manager.py
+++ b/stata_kernel/code_manager.py
@@ -79,7 +79,22 @@ class CodeManager(object):
         self.tokens_nocomments = self.tokenize_code(text)
 
     def _is_complete(self):
+        """Determine whether the code provided is complete
+
+        Ways in which code entered is not complete:
+        - If in the middle of a block construct, i.e. foreach, program, input
+        - If the last token provided is inside a line-continuation comment, i.e.
+          `di 2 + ///` or `di 2 + /*`.
+        - If in a #delimit ; block and there are non-whitespace characters after
+          the last semicolon.
+        """
+
+        # block constructs
         if str(self.tokens_nocomments[-1][0]) == 'Token.MatchingBracket.Other':
+            return False
+
+        # last token a line-continuation comment
+        if str(self.tokens[-1][0]) in ['Token.Comment.Multiline', 'Token.Comment.Special']:
             return False
 
         if self.ends_sc:

--- a/stata_kernel/kernel.py
+++ b/stata_kernel/kernel.py
@@ -57,6 +57,15 @@ class StataKernel(Kernel):
 
         # Tokenize code and return code chunks
         cm = CodeManager(code, self.sc_delimit_mode)
+        # Send message if delimiter changed. NOTE: This uses the delimiter at
+        # the _end_ of the code block. It prints only if the delimiter at the
+        # end is different than the one before the chunk.
+        if cm.ends_sc != self.sc_delimit_mode:
+            delim = ';' if cm.ends_sc else 'cr'
+            self.send_response(
+                self.iopub_socket, 'stream', {
+                    'text': 'delimiter now {}'.format(delim),
+                    'name': 'stdout'})
         self.sc_delimit_mode = cm.ends_sc
 
         rc, imgs, res = self.stata.do(cm.get_chunks(), self.magics)

--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -93,6 +93,7 @@ class StataMagics():
         # 'restart',
         'locals',
         'globals',
+        'delimit',
         'time',
         'timeit']
 
@@ -253,6 +254,11 @@ class StataMagics():
 
     def magic_locals(self, code, kernel):
         return self.magic_globals(code, kernel, True)
+
+    def magic_delimit(self, code, kernel):
+        delim = ';' if kernel.sc_delimit_mode else 'cr'
+        print_kernel('The delimiter is currently: {}'.format(delim), kernel)
+        return ''
 
     def magic_time(self, code, kernel):
         try:


### PR DESCRIPTION
This fixes:

- (Not a #delimit fix) Prevents completion when last token is a multiline comment
![image](https://user-images.githubusercontent.com/15164633/44007798-ab847d6a-9e69-11e8-9f1b-6d6a1480ff52.png)
- Adds a magic named `%delimit` that prints the current delmiter
- Logs to the screen when the delimiter changes