### PR TITLE
[Draft] Mata support

### DIFF
--- a/stata_kernel/ado/_StataKernelCompletions.ado
+++ b/stata_kernel/ado/_StataKernelCompletions.ado
@@ -3,6 +3,8 @@ program _StataKernelCompletions
     local userTrace `c(trace)'
     set trace off
     syntax [varlist]
+    disp "%mata%"
+    mata mata desc
     disp "%varlist%"
     disp `"`varlist'"'
     disp "%globals%"

--- a/stata_kernel/code_manager.py
+++ b/stata_kernel/code_manager.py
@@ -8,18 +8,43 @@ class CodeManager(object):
     """Class to deal with text before sending to Stata
     """
 
-    def __init__(self, code, semicolon_delimit=False):
+    def __init__(self, code, semicolon_delimit=False, mata_mode=False):
+
+        # mata goes first since it obeys #delimit!
         if semicolon_delimit:
             code = '#delimit ;\n' + code
+            if mata_mode:
+                code = 'mata;\n' + code
+        elif mata_mode:
+            code = 'mata\n' + code
+
+        print('debugz0', code)
         self.input = code
         self.tokens = self.tokenize_code(code)
+        print('debugz1', self.tokens)
         self.tokens_nocomments = self.remove_comments()
+        print('debugz2', self.tokens_nocomments)
 
         self.ends_sc = str(self.tokens_nocomments[-1][0]) in [
             'Token.Keyword.Namespace', 'Token.Keyword.Reserved']
 
+        self.ends_mata = False
+        if len(self.tokens_nocomments) > 1:
+            token, chunk = self.tokens_nocomments[-2]
+            self.ends_mata = str(token) == 'Token.Keyword.Reserved'
+            print('debugz3.1', token, chunk)
+
+        print('debugz3', self.ends_sc, self.ends_mata, self.tokens_nocomments)
+
         self.has_sc_delimits = 'Token.Keyword.Namespace' in [
             str(x[0]) for x in self.tokens_nocomments]
+        self.has_mata_mode = 'Token.Other' in [
+            str(x[0]) for x in self.tokens_nocomments]
+        print('debugz4', self.has_sc_delimits, self.has_mata_mode)
+
+        if mata_mode:
+            self.tokens_nocomments = self.tokens_nocomments[1:]
+
         self.is_complete = self._is_complete()
 
         if self.has_sc_delimits:

--- a/stata_kernel/code_manager.py
+++ b/stata_kernel/code_manager.py
@@ -25,9 +25,7 @@ class CodeManager(object):
 
         # First use the Comment and Delimiting lexer
         # first pass
-        # print('debugz0', code)
         self.tokens_fp_all = self.tokenize_first_pass(code)
-        # print('debugz0', self.tokens_fp_all)
         self.tokens_fp_no_comments = self.remove_comments(self.tokens_fp_all)
 
         if not self.tokens_fp_no_comments:
@@ -36,7 +34,6 @@ class CodeManager(object):
         self.ends_sc = str(self.tokens_fp_no_comments[-1][0]) in [
             'Token.Keyword.Namespace', 'Token.Keyword.Reserved']
 
-        # print('debugz1', self.tokens_fp_no_comments)
         tokens_nl_delim = self.convert_delimiter(self.tokens_fp_no_comments)
         text = ''.join([x[1] for x in tokens_nl_delim])
         self.tokens_final = self.tokenize_second_pass(text)
@@ -63,20 +60,11 @@ class CodeManager(object):
         # else:
         #     self.ends_mata = False
 
-        # print('debugz3', mata_mode, self.has_mata_mode, self.ends_mata)
-        # print('debugz4', self.tokens_final)
-        # if mata_mode:
-        #     self.tokens_final = self.tokens_final[1:]
-
-        # print('debugz4', self.tokens_final)
         self.is_complete = self._is_complete()
-        # print('debugz5', self.is_complete)
 
         # Append "" to mata to force statements like "if" to end.
         if self.has_mata_mode:
             self.tokens_final += [('Token.Text', '""')]
-
-        # print('debugz6', self.tokens_final)
 
     def tokenize_first_pass(self, code):
         """Tokenize input code for Comments and Delimit blocks
@@ -96,9 +84,7 @@ class CodeManager(object):
                 - Keyword.Namespace (code inside #delimit ; block)
                 - Keyword.Reserved (; delimiter)
         """
-        # print("debugfp", code)
         comment_lexer = CommentAndDelimitLexer(stripall=False, stripnl=False)
-        # print("debugfp", list(lex(code, comment_lexer)))
         return [x for x in lex(code, comment_lexer)]
 
     def remove_comments(self, tokens):
@@ -187,7 +173,6 @@ class CodeManager(object):
                 ind for ind, x in enumerate(self.tokens_fp_all)
                 if (str(x[0]) == 'Token.Keyword.Reserved') and x[1] == ';']
 
-            # print('debugi1', inds)
             if not inds:
                 inds = [0]
 
@@ -195,7 +180,6 @@ class CodeManager(object):
             # If so, then it's not complete
             tr_text = ''.join([
                 x[1] for x in self.tokens_fp_all[max(inds) + 1:]]).strip()
-            # print('debugi2', tr_text)
             if tr_text:
                 return False
 

--- a/stata_kernel/code_manager.py
+++ b/stata_kernel/code_manager.py
@@ -18,12 +18,12 @@ class CodeManager(object):
         elif mata_mode:
             code = 'mata\n' + code
 
-        print('debugz0', code)
+        # print('debugz0', code)
         self.input = code
         self.tokens = self.tokenize_code(code)
-        print('debugz1', self.tokens)
+        # print('debugz1', self.tokens)
         self.tokens_nocomments = self.remove_comments()
-        print('debugz2', self.tokens_nocomments)
+        # print('debugz2', self.tokens_nocomments)
 
         self.ends_sc = str(self.tokens_nocomments[-1][0]) in [
             'Token.Keyword.Namespace', 'Token.Keyword.Reserved']
@@ -32,15 +32,15 @@ class CodeManager(object):
         if len(self.tokens_nocomments) > 1:
             token, chunk = self.tokens_nocomments[-2]
             self.ends_mata = str(token) == 'Token.Keyword.Reserved'
-            print('debugz3.1', token, chunk)
+            # print('debugz3.1', token, chunk)
 
-        print('debugz3', self.ends_sc, self.ends_mata, self.tokens_nocomments)
+        # print('debugz3', self.ends_sc, self.ends_mata, self.tokens_nocomments)
 
         self.has_sc_delimits = 'Token.Keyword.Namespace' in [
             str(x[0]) for x in self.tokens_nocomments]
         self.has_mata_mode = 'Token.Other' in [
             str(x[0]) for x in self.tokens_nocomments]
-        print('debugz4', self.has_sc_delimits, self.has_mata_mode)
+        # print('debugz4', self.has_sc_delimits, self.has_mata_mode)
 
         if mata_mode:
             self.tokens_nocomments = self.tokens_nocomments[1:]

--- a/stata_kernel/completions.py
+++ b/stata_kernel/completions.py
@@ -28,7 +28,7 @@ class CompletionsManager(object):
         self.matalist = re.compile(
             r"(?:.*?)\s(\S+)\s*$", flags=re.MULTILINE + re.DOTALL)
 
-        self.mataclean = regex.compile(r"\W")
+        self.mataclean = regex.compile(r"\W.*?(\b|$)")
 
         self.matainline = regex.compile(r"^m(ata)?\b").search
 

--- a/stata_kernel/completions.py
+++ b/stata_kernel/completions.py
@@ -238,18 +238,24 @@ class CompletionsManager(object):
         return suggestions
 
     def quickdo(self, code, kernel):
+        """Runs a single line in the Stata console or session
+        """
         if kernel.stata.execution_mode == 'console':
-            res, timer = kernel.stata.do_console(code)
+            res, timer = kernel.stata.do_console(
+                kernel.stata._mata_escape(code))
         else:
             log_path = kernel.stata.cache_dir / '.stata_kernel_completions.log'
             log_cmd = 'log using `"{}"\', replace text'.format(log_path)
-            rc = kernel.stata.automate('DoCommand', log_cmd)
+            rc = kernel.stata.automate(
+                'DoCommand', kernel.stata._mata_escape(log_cmd))
             if not rc:
                 fh = open(log_path, 'r')
                 fh.read()
-                rc, timer = kernel.stata.do_aut_sync(code)
+                rc, timer = kernel.stata.do_aut_sync(
+                    kernel.stata._mata_escape(code))
                 res = fh.read()
-                kernel.stata.automate('DoCommand', 'cap log close')
+                kernel.stata.automate(
+                    'DoCommand', kernel.stata._mata_escape('cap log close'))
                 fh.close()
 
         return res

--- a/stata_kernel/completions.py
+++ b/stata_kernel/completions.py
@@ -192,12 +192,10 @@ class CompletionsManager(object):
             # scalar context.
             env += env_add
 
-        # print("debug", env, code)
         if env == 9:
             matacontext = self.matacontext(code)
             if matacontext:
                 st, context, quote, pre = matacontext.groupdict().values()
-                # print("debug", st, context, quote, pre)
                 varlist = [
                     'data',
                     'sdata',
@@ -236,7 +234,6 @@ class CompletionsManager(object):
                 if quote:
                     posextra += len(quote) + 1
 
-                # print("debug", posextra)
                 if context in varlist:
                     env = 0
                 elif context in _globals:
@@ -255,7 +252,6 @@ class CompletionsManager(object):
                     posextra = 0
 
                 pos += posextra
-                # print("debug", env, pos, posextra, code[:pos])
 
         return env, pos, code[pos:], rcomp
 

--- a/stata_kernel/kernel.py
+++ b/stata_kernel/kernel.py
@@ -62,37 +62,30 @@ class StataKernel(Kernel):
         # Enter mata if applicable
         self.stata.mata_mode = cm.has_mata_mode and not cm.ends_mata
         if self.stata.mata_mode:
-            # print('\tdebug1', 'mata')
             self.stata.prompt = self.stata.mata_prompt
             self.stata.prompt_regex = self.stata.mata_prompt_regex
             # Turn off plot magic in mata
             # if (self.magics.graphs != 2):
             self.magics.graphs = 0
         else:
-            # print('\tdebug1', 'stata')
             self.stata.prompt = self.stata.stata_prompt
             self.stata.prompt_regex = self.stata.stata_prompt_regex
 
         # Execute code chunk
-        # print('\tdebug2', cm.get_chunks())
         rc, imgs, res = self.stata.do(cm.get_chunks(), self.magics)
 
         # If mata error, restart
-        # print("debug0", self.stata.mata_mode)
         if self.stata.mata_mode and (rc == 3000):
             self.stata.prompt = self.stata.stata_prompt
             self.stata.prompt_regex = self.stata.stata_prompt_regex
             mata_restart = [('Token.Text', 'end')]
             _rc, _imgs, _res = self.stata.do(mata_restart, self.magics)
-            # print("debuge", res)
             self.stata.prompt = self.stata.mata_prompt
             self.stata.prompt_regex = self.stata.mata_prompt_regex
             _rc, _imgs, _res = self.stata.do([('Token.Text', 'mata')], self.magics)
-            # print("debugf", _res)
             res = "Incomplete or invalid input; restarting...\n"
             res += _res
         elif self.stata.mata_mode and (rc == 0):
-            # print('debug', self.stata.mata_trim.search(res))
             res = self.stata.mata_trim.sub('', res)
 
         stream_content = {'text': res}
@@ -174,12 +167,9 @@ class StataKernel(Kernel):
         when closed.
 
         """
-        # print("debugic")
         if self.is_complete(code):
-            # print("debugic1")
             return {'status': 'complete'}
 
-        # print("debugic2")
         return {'status': 'incomplete', 'indent': '    '}
 
     def do_complete(self, code, cursor_pos):
@@ -199,5 +189,4 @@ class StataKernel(Kernel):
     def is_complete(self, code):
         c = CodeManager(
             code, self.sc_delimit_mode, self.stata.mata_mode).is_complete
-        # print("debugc", c)
         return c

--- a/stata_kernel/kernel.py
+++ b/stata_kernel/kernel.py
@@ -1,4 +1,5 @@
 from ipykernel.kernelbase import Kernel
+from timeit import default_timer
 
 from .completions import CompletionsManager
 from .code_manager import CodeManager
@@ -21,6 +22,7 @@ class StataKernel(Kernel):
 
         self.graphs = {}
         self.magics = StataMagics()
+        self.timer_dict = {}
 
         self.sc_delimit_mode = False
         self.stata = StataSession()
@@ -40,6 +42,8 @@ class StataKernel(Kernel):
         if not self.is_complete(code):
             return {'status': 'error', 'execution_count': self.execution_count}
 
+        self._timer()
+
         # Search for magics in the code
         code = self.magics.magic(code, self)
 
@@ -56,23 +60,39 @@ class StataKernel(Kernel):
         if self.magics.quit_early:
             return self.magics.quit_early
 
+        # If %timer is on, always profile
+        if self.magics.timer:
+            if self.magics.timer_profile:
+                self.magics.timeit = 2
+            else:
+                self.timeit = 1
+
+        self._timer('StataMagics')
+
         # Tokenize code and return code chunks
         cm = CodeManager(code, self.sc_delimit_mode, self.stata.mata_mode)
+        # print('debugz', self.stata.mata_mode)
 
         # Enter mata if applicable
         self.stata.mata_mode = cm.has_mata_mode and not cm.ends_mata
+        # print('debugw', self.stata.mata_mode)
         if self.stata.mata_mode:
+            # print('debugx', 'mata')
             self.stata.prompt = self.stata.mata_prompt
             self.stata.prompt_regex = self.stata.mata_prompt_regex
             # Turn off plot magic in mata
             # if (self.magics.graphs != 2):
             self.magics.graphs = 0
         else:
+            # print('debugx', 'stata')
             self.stata.prompt = self.stata.stata_prompt
             self.stata.prompt_regex = self.stata.stata_prompt_regex
 
+        self._timer('CodeManager')
+
         # Execute code chunk
         rc, imgs, res = self.stata.do(cm.get_chunks(), self.magics)
+        self._timer('StataSession')
 
         # If mata error, restart
         if self.stata.mata_mode and (rc == 3000):
@@ -83,15 +103,17 @@ class StataKernel(Kernel):
             self.stata.prompt = self.stata.mata_prompt
             self.stata.prompt_regex = self.stata.mata_prompt_regex
             _rc, _imgs, _res = self.stata.do([('Token.Text', 'mata')], self.magics)
-            res = "Incomplete or invalid input; restarting...\n"
+            res = "Incomplete or invalid input; restarting mata...\n"
             res += _res
         elif self.stata.mata_mode and (rc == 0):
             res = self.stata.mata_trim.sub('', res)
 
+        self._timer('MataRefresh')
         stream_content = {'text': res}
 
         # Post magic results, if applicable
         self.magics.post(self)
+        self._timer('StataMagicsPost')
 
         # The base class increments the execution count
         return_obj = {'execution_count': self.execution_count}
@@ -107,6 +129,7 @@ class StataKernel(Kernel):
         if silent:
             # Refresh completions
             self.completions.refresh(self)
+            self._timer('CompletionsManager', True)
             return return_obj
 
         if res.strip():
@@ -146,6 +169,7 @@ class StataKernel(Kernel):
 
         # Refresh completions
         self.completions.refresh(self)
+        self._timer('CompletionsManager', True)
         return return_obj
 
     def do_shutdown(self, restart):
@@ -189,3 +213,62 @@ class StataKernel(Kernel):
         c = CodeManager(
             code, self.sc_delimit_mode, self.stata.mata_mode).is_complete
         return c
+
+    def _timer(self, step = None, end = False):
+        if self.magics.timer:
+            if self.magics.timer_profile:
+                self.magics.timeit = 2
+            else:
+                self.magics.timeit = 1
+
+        if step:
+            self.timer_dict[step] = default_timer() - self.timer_dict['timer']
+            self.timer_dict['timer'] = default_timer()
+        else:
+            self.timer_dict = {}
+            self.timer_dict['all'] = default_timer()
+            self.timer_dict['timer'] = default_timer()
+
+        if end:
+            self.timer_dict['all'] = default_timer() - self.timer_dict['all']
+
+            if self.magics.timer:
+                lens = 0
+                sens = 0
+                tprint = []
+                sprint = []
+
+                for k, t in self.timer_dict.items():
+                    if k == 'all':
+                        tall = t
+                        continue
+                    elif k == 'timer':
+                        continue
+
+                    tfmt = "{0:.2f}".format(t)
+                    tprint += [(tfmt, k)]
+                    lens = max(lens, len(tfmt))
+
+                for k, t in self.stata.timer_dict.items():
+                    if k == 'all':
+                        continue
+                    elif k == 'timer':
+                        continue
+
+                    sfmt = "{0:.2f}".format(t)
+                    sprint += [(sfmt, k)]
+                    sens = max(sens, len(sfmt))
+
+                self._print("Wall time (total): {0:.2f}\n".format(tall))
+                fmt = "\t{{0:{0}}} {{1}}\n".format(lens)
+                smt = "\t\t{{0:{0}}} {{1}}\n".format(sens)
+                for t, k in tprint:
+                    self._print(fmt.format(t, k))
+                    if k == 'StataSession':
+                        for _t, _k in sprint:
+                            self._print(smt.format(_t, _k))
+
+    def _print(self, msg):
+        stream_content = {'text': msg}
+        stream_content['name'] = 'stdout'
+        self.send_response(self.iopub_socket, 'stream', stream_content)

--- a/stata_kernel/kernel.py
+++ b/stata_kernel/kernel.py
@@ -187,7 +187,7 @@ class StataKernel(Kernel):
         # variable, local, etc.
         env, pos, chunk, rcomp = self.completions.get_env(
             code[:cursor_pos], code[cursor_pos:(cursor_pos + 2)],
-            self.sc_delimit_mode)
+            self.sc_delimit_mode, self.stata.mata_mode)
 
         return {
             'status': 'ok',

--- a/stata_kernel/kernel.py
+++ b/stata_kernel/kernel.py
@@ -62,15 +62,18 @@ class StataKernel(Kernel):
         # Enter mata if applicable
         self.stata.mata_mode = cm.has_mata_mode and not cm.ends_mata
         if self.stata.mata_mode:
+            # print('\tdebug1', 'mata')
             self.stata.prompt = self.stata.mata_prompt
             self.stata.prompt_regex = self.stata.mata_prompt_regex
             if (self.magics.graphs != 2):
                 self.magics.graphs = 0
         else:
+            # print('\tdebug1', 'stata')
             self.stata.prompt = self.stata.stata_prompt
             self.stata.prompt_regex = self.stata.stata_prompt_regex
 
         # Execute code chunk
+        # print('\tdebug2', cm.get_chunks())
         rc, imgs, res = self.stata.do(cm.get_chunks(), self.magics)
         stream_content = {'text': res}
 

--- a/stata_kernel/kernel.py
+++ b/stata_kernel/kernel.py
@@ -56,25 +56,21 @@ class StataKernel(Kernel):
             return self.magics.quit_early
 
         # Tokenize code and return code chunks
-        print('debug0', code)
         cm = CodeManager(code, self.sc_delimit_mode, self.stata.mata_mode)
 
         # Enter #delimit ; or mata mode
         self.sc_delimit_mode = cm.ends_sc
         self.stata.mata_mode = cm.has_mata_mode and not cm.ends_mata
         if self.stata.mata_mode:
-            print('debug1', 'mata')
             self.stata.prompt = self.stata.mata_prompt
             self.stata.prompt_regex = self.stata.mata_prompt_regex
             if (self.magics.graphs != 2):
                 self.magics.graphs = 0
         else:
-            print('debug2', 'stata')
             self.stata.prompt = self.stata.stata_prompt
             self.stata.prompt_regex = self.stata.stata_prompt_regex
 
         # Execute code chunk
-        print('debug3', cm.get_chunks())
         rc, imgs, res = self.stata.do(cm.get_chunks(), self.magics)
         stream_content = {'text': res}
 

--- a/stata_kernel/stata_lexer.py
+++ b/stata_kernel/stata_lexer.py
@@ -29,13 +29,30 @@ class StataLexer(RegexLexer):
         'root': [
             include('comments'),
             include('strings'),
+            (r'^\s*m(ata)?[^\r\n\S]*:?[^\r\n\S]*$', Token.Other, 'mata'),
             (r'^[^\n]*?\{', Token.MatchingBracket.Other, 'block'),
             (r'^\s*(pr(ogram|ogra|ogr|og|o)?)\s+(?!di|dr|l)(de(fine|fin|fi|f)?\s+)?', Token.MatchingBracket.Other, 'program'),
             (r'^\s*inp(u|ut)?', Token.MatchingBracket.Other, 'program'),
             (r'^\s*#d(e|el|eli|elim|elimi|elimit)?\s*;\s*?$', Comment.Single, 'delimit;'),
-            (r'^\s*m(ata)?[^\r\n\S]*:?[^\r\n\S]*$', Token.Other, 'mata'),
             (r'.', Text),
         ],
+
+        'mata': [
+            ('^\s*end(\s|[^\s\w\.]).*?$', Token.Other, '#pop'),
+            include('mata-comments'),
+            include('strings'),
+            (r'[\r\n]\s*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Keyword.Reserved),
+            (r'^[^\n]*?\{', Token.MatchingBracket.Other, 'block'),
+            (r'^\s*#d(e|el|eli|elim|elimi|elimit)?\s*;\s*?$', Comment.Single, 'delimit;'),
+            (r'.', Text),
+        ],
+        'mata-comments': [
+            # Just exclude linestar
+            (r'(^//|(?<=\s)//)(?!/)', Comment.Single, 'comments-double-slash'),
+            (r'/\*', Comment.Multiline, 'comments-block'),
+            (r'(^///|(?<=\s)///)', Comment.Special, 'comments-triple-slash')
+        ],
+
         'block': [
             (r'\{', Token.MatchingBracket.Other, '#push'),
             (r'\}', Token.MatchingBracket.Other, '#pop'),
@@ -112,20 +129,6 @@ class StataLexer(RegexLexer):
         'string-regular-inside-blocks': [
             (r'(")(?!\')|(?=\n)', Token.MatchingBracket.Other, '#pop'),
             (r'.', Token.MatchingBracket.Other)
-        ],
-
-        'mata': [
-            ('^\s*end(\s|[^\s\w\.]).*?$', Token.Other, '#pop'),
-            include('mata-comments'),
-            include('strings'),
-            (r'[\r\n]\s*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Keyword.Reserved),
-            # (r'.', Token.Keyword.Namespace),
-        ],
-        'mata-comments': [
-            # Just exclude linestar
-            (r'(^//|(?<=\s)//)(?!/)', Comment.Single, 'comments-double-slash'),
-            (r'/\*', Comment.Multiline, 'comments-block'),
-            (r'(^///|(?<=\s)///)', Comment.Special, 'comments-triple-slash')
         ],
 
         'delimit;': [

--- a/stata_kernel/stata_lexer.py
+++ b/stata_kernel/stata_lexer.py
@@ -21,6 +21,8 @@ class StataLexer(RegexLexer):
 
     Text: Arbitrary text
     Token.Keyword.Reserved: Delimiter (either \\n or ;), depending on the block
+
+    Token.Other is used to detect mata
     """
     flags = re.MULTILINE | re.DOTALL
     tokens = {
@@ -31,6 +33,7 @@ class StataLexer(RegexLexer):
             (r'^\s*(pr(ogram|ogra|ogr|og|o)?)\s+(?!di|dr|l)(de(fine|fin|fi|f)?\s+)?', Token.MatchingBracket.Other, 'program'),
             (r'^\s*inp(u|ut)?', Token.MatchingBracket.Other, 'program'),
             (r'^\s*#d(e|el|eli|elim|elimi|elimit)?\s*;\s*?$', Comment.Single, 'delimit;'),
+            (r'^\s*m(ata)?[^\r\n\S]*:?[^\r\n\S]*$', Token.Other, 'mata'),
             (r'.', Text),
         ],
         'block': [
@@ -111,6 +114,19 @@ class StataLexer(RegexLexer):
             (r'.', Token.MatchingBracket.Other)
         ],
 
+        'mata': [
+            ('^\s*end(\s|[^\s\w\.]).*?$', Token.Other, '#pop'),
+            include('mata-comments'),
+            include('strings'),
+            (r'[\r\n]\s*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Keyword.Reserved),
+            # (r'.', Token.Keyword.Namespace),
+        ],
+        'mata-comments': [
+            # Just exclude linestar
+            (r'(^//|(?<=\s)//)(?!/)', Comment.Single, 'comments-double-slash'),
+            (r'/\*', Comment.Multiline, 'comments-block'),
+            (r'(^///|(?<=\s)///)', Comment.Special, 'comments-triple-slash')
+        ],
 
         'delimit;': [
             (r'^\s*#d(e|el|eli|elim|elimi|elimit)?\s+cr\s*?$', Comment.Single, '#pop'),

--- a/stata_kernel/stata_lexer.py
+++ b/stata_kernel/stata_lexer.py
@@ -22,8 +22,6 @@ class StataLexer(RegexLexer):
     Text: Arbitrary text
     Token.Keyword.Reserved: Delimiter (either \\n or ;), depending on the block
 
-    Token.Other is used to detect mata
-    Token.Aborted is used to detect mata exit
     NOTE: Test mata does not end if end is inside a string, comment
     """
     flags = re.MULTILINE | re.DOTALL
@@ -36,7 +34,7 @@ class StataLexer(RegexLexer):
             # of syntactic chunks.
             (r'^[^\n]*?`"', Text, 'string-compound'),
             (r'^[^\n]*?(?<!`)"', Text, 'string-regular'),
-            (r'^[^\n]*?[^\r\n\S]*m(ata)?[^\r\n\S]*:?[^\r\n\S]*$', Token.Other, 'mata'),
+            (r'^[^\r\n\S]*m(ata)?[^\r\n\S]*:?[^\r\n\S]*$', Token.Mata.Open, 'mata'),
             (r'^[^\n]*?\{', Token.MatchingBracket.Other, 'block'),
             (r'^\s*(pr(ogram|ogra|ogr|og|o)?)\s+(?!di|dr|l)(de(fine|fin|fi|f)?\s+)?', Token.MatchingBracket.Other, 'program'),
             (r'^\s*inp(u|ut)?', Token.MatchingBracket.Other, 'program'),
@@ -46,17 +44,33 @@ class StataLexer(RegexLexer):
         'mata': [
             include('strings'),
             (r'^[^\n]*?\{', Token.MatchingBracket.Other, 'block'),
-            (r'^[^\n]*?\(', Token.MatchingBracket.Other, 'paren'),
-            (r'[\r\n][^\r\n\S]*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Aborted, '#pop'),
+            (r'^[^\r\n]*?\(', Token.MatchingBracket.Paren, 'paren'),
+            (r'[\r\n][^\r\n\S]*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Mata.Close, '#pop'),
             (r'.', Text),
         ],
-
         'paren': [
-            (r'\(', Token.MatchingBracket.Other, '#push'),
-            (r'\)', Token.MatchingBracket.Other, '#pop'),
-            include('strings-inside-blocks'),
-            (r'.', Token.MatchingBracket.Other)
+            (r'\(', Token.MatchingBracket.Paren, '#push'),
+            (r'\)[^\r\n]*?(?=\)|$|[\r\n])', Token.MatchingBracket.Paren, '#pop'),
+            (r'\)[^\r\n]*?\(', Token.MatchingBracket.Paren),
+            include('strings-inside-paren'),
+            (r'.', Token.MatchingBracket.Paren)
         ],
+        'strings-inside-paren': [
+            # `"compound string"'
+            (r'`"', Token.MatchingBracket.Paren, 'string-compound-inside-paren'),
+            # "string"
+            (r'(?<!`)"', Token.MatchingBracket.Paren, 'string-regular-inside-paren'),
+        ],
+        'string-compound-inside-paren': [
+            (r'`"', Token.MatchingBracket.Paren, '#push'),
+            (r'"\'', Token.MatchingBracket.Paren, '#pop'),
+            (r'.', Token.MatchingBracket.Paren)
+        ],
+        'string-regular-inside-paren': [
+            (r'(")(?!\')|(?=\n)', Token.MatchingBracket.Paren, '#pop'),
+            (r'.', Token.MatchingBracket.Paren)
+        ],
+
         'block': [
             (r'\{', Token.MatchingBracket.Other, '#push'),
             (r'\}', Token.MatchingBracket.Other, '#pop'),
@@ -120,8 +134,6 @@ class CommentAndDelimitLexer(RegexLexer):
     Text: Arbitrary text
     Token.Keyword.Reserved: Delimiter (either \\n or ;), depending on the block
 
-    Token.Other is used to detect mata
-    Token.Aborted is used to detect mata exit
     NOTE: Test mata does not end if end is inside a string, comment even multi-line
     """
     flags = re.MULTILINE | re.DOTALL
@@ -131,7 +143,7 @@ class CommentAndDelimitLexer(RegexLexer):
             include('comments'),
             include('strings'),
             (r'^\s*#d(e|el|eli|elim|elimi|elimit)?\s*;\s*?$', Comment.Single, 'delimit;'),
-            (r'^[^\n]*?[^\r\n\S]*m(ata)?[^\r\n\S]*:?[^\r\n\S]*$', Token.Other, 'mata'),
+            (r'^[^\r\n\S]*m(ata)?[^\r\n\S]*:?[^\r\n\S]*$', Token.Mata.Open, 'mata'),
             (r'.', Text),
         ],
         'mata': [
@@ -140,7 +152,7 @@ class CommentAndDelimitLexer(RegexLexer):
             (r'/\*', Comment.Multiline, 'comments-block'),
             (r'(^///|(?<=\s)///)', Comment.Special, 'comments-triple-slash'),
             include('strings'),
-            (r'[\r\n][^\r\n\S]*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Aborted, '#pop'),
+            (r'[\r\n][^\r\n\S]*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Mata.Close, '#pop'),
             (r'.', Text),
         ],
         'mata-delimit': [
@@ -149,7 +161,7 @@ class CommentAndDelimitLexer(RegexLexer):
             (r'/\*', Comment.Multiline, 'delimit;-comments-block'),
             (r'(^///|(?<=\s)///)', Comment.Special, 'delimit;-comments-triple-slash'),
             include('delimit;-strings'),
-            (r'(\A|;)\s*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Aborted, '#pop'),
+            (r'(\A|;)\s*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Mata.Close, '#pop'),
             (r';', Token.Keyword.Reserved),
             (r'.', Text),
         ],
@@ -206,7 +218,7 @@ class CommentAndDelimitLexer(RegexLexer):
         'delimit;': [
             (r'^\s*#d(e|el|eli|elim|elimi|elimit)?\s+cr\s*?$', Comment.Single, '#pop'),
             # NOTE(mauricio): XX check nesting as mata captures ; as text
-            (r'(\A|;)\s*m(ata)?\s*:?\s*;', Token.Other, 'mata-delimit'),
+            (r'(\A|;)\s*m(ata)?\s*:?\s*;', Token.Mata.Open, 'mata-delimit'),
             include('delimit;-comments'),
             include('delimit;-strings'),
             (r';', Token.Keyword.Reserved),

--- a/stata_kernel/stata_lexer.py
+++ b/stata_kernel/stata_lexer.py
@@ -44,13 +44,19 @@ class StataLexer(RegexLexer):
         ],
 
         'mata': [
-            (r'[\r\n][^\r\n\S]*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Aborted, '#pop'),
             include('strings'),
-            # (r'[\r\n][^\r\n\S]*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Aborted),
             (r'^[^\n]*?\{', Token.MatchingBracket.Other, 'block'),
+            (r'^[^\n]*?\(', Token.MatchingBracket.Other, 'paren'),
+            (r'[\r\n][^\r\n\S]*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Aborted, '#pop'),
             (r'.', Text),
         ],
 
+        'paren': [
+            (r'\(', Token.MatchingBracket.Other, '#push'),
+            (r'\)', Token.MatchingBracket.Other, '#pop'),
+            include('strings-inside-blocks'),
+            (r'.', Token.MatchingBracket.Other)
+        ],
         'block': [
             (r'\{', Token.MatchingBracket.Other, '#push'),
             (r'\}', Token.MatchingBracket.Other, '#pop'),
@@ -122,30 +128,29 @@ class CommentAndDelimitLexer(RegexLexer):
     tokens = {
         'root': [
             # NOTE(mauricio): Is it important to include comments and strings first?
-            (r'^\s*#d(e|el|eli|elim|elimi|elimit)?\s*;\s*?$', Comment.Single, 'delimit;'),
             include('comments'),
             include('strings'),
+            (r'^\s*#d(e|el|eli|elim|elimi|elimit)?\s*;\s*?$', Comment.Single, 'delimit;'),
             (r'^[^\n]*?[^\r\n\S]*m(ata)?[^\r\n\S]*:?[^\r\n\S]*$', Token.Other, 'mata'),
             (r'.', Text),
         ],
         'mata': [
             # Just exclude linestar
-            (r'[\r\n][^\r\n\S]*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Aborted, '#pop'),
             (r'(^//|(?<=\s)//)(?!/)', Comment.Single, 'comments-double-slash'),
             (r'/\*', Comment.Multiline, 'comments-block'),
             (r'(^///|(?<=\s)///)', Comment.Special, 'comments-triple-slash'),
             include('strings'),
-            # (r'[\r\n][^\r\n\S]*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Aborted),
+            (r'[\r\n][^\r\n\S]*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Aborted, '#pop'),
             (r'.', Text),
         ],
         'mata-delimit': [
             # Just exclude linestar
-            (r'(\A|;)\s*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Aborted, '#pop'),
             (r'((^\s+//)|(?<=;\s)\s*//)(?!/)', Comment.Single, 'delimit;-comments-double-slash'),
             (r'/\*', Comment.Multiline, 'delimit;-comments-block'),
             (r'(^///|(?<=\s)///)', Comment.Special, 'delimit;-comments-triple-slash'),
             include('delimit;-strings'),
-            # (r'(\A|;)\s*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Aborted),
+            (r'(\A|;)\s*end(?=(\s|[^\s\w\.]).*?$|$)', Token.Aborted, '#pop'),
+            (r';', Token.Keyword.Reserved),
             (r'.', Text),
         ],
 

--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -94,7 +94,8 @@ class StataMagics():
         'locals',
         'globals',
         'time',
-        'timeit']
+        'timeit',
+        'status']
 
     def __init__(self):
         self.quit_early = None
@@ -291,6 +292,18 @@ class StataMagics():
         self.status = -1
         print_kernel("Magic restart has not been implemented.", kernel)
         return code
+
+    def magic_status(self, code, kernel):
+        self.status = -1
+        delim = ';' if kernel.sc_delimit_mode else 'cr'
+        env = 'mata' if kernel.stata.mata_mode else 'stata'
+        info = (
+            kernel.implementation, kernel.implementation_version,
+            kernel.language, kernel.language_version)
+        print_kernel('{0} {1} for {2} {3}'.format(*info), kernel)
+        print_kernel('\tDelimiter:   {}'.format(delim), kernel)
+        print_kernel('\tEnvironment: {}'.format(env), kernel)
+        return ''
 
 
 # ---------------------------------------------------------------------

--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -66,6 +66,14 @@ class MagicParsers():
             '--profile', dest='profile', action='store_true',
             help="Profile each line of code", required=False)
 
+        self.timer = StataParser(prog='%timer', kernel=kernel)
+        self.timer.add_argument(
+            'on', nargs=1, type=str, metavar='{on|off}',
+            help="Timer on (time everything) or off", choices=["on", "off"])
+        self.timer.add_argument(
+            '--profile', dest='profile', action='store_true',
+            help="Profile each chunk of code", required=False)
+
         self.timeit = StataParser(prog='%timeit', kernel=kernel)
         self.timeit.add_argument(
             'code', nargs='*', type=str, metavar='CODE', help="Code to run")
@@ -87,6 +95,9 @@ class StataMagics():
     magic_regex = re.compile(
         r'\A%(?P<magic>.+?)(?P<code>\s+.*)?\Z', flags=re.DOTALL + re.MULTILINE)
 
+    timer = False
+    timer_profile = False
+
     available_magics = [
         'plot',
         'graph',
@@ -96,6 +107,7 @@ class StataMagics():
         'globals',
         'delimit',
         'time',
+        'timer',
         'timeit',
         'status']
 
@@ -143,7 +155,7 @@ class StataMagics():
     def post(self, kernel):
         if self.timeit in [1, 2]:
             total, _ = self.time_profile.pop()
-            print_kernel("Wall time (seconds): {0:.2f}".format(total), kernel)
+            print_kernel("Wall time (Stata): {0:.2f}".format(total), kernel)
 
             if (len(self.time_profile) > 0) and (self.timeit == 2):
                 lens = 0
@@ -311,6 +323,18 @@ class StataMagics():
         print_kernel('\tDelimiter:   {}'.format(delim), kernel)
         print_kernel('\tEnvironment: {}'.format(env), kernel)
         return ''
+
+    def magic_timer(self, code, kernel):
+        try:
+            timer = code.strip().split(' ')
+            args = vars(self.parse.timer.parse_args(timer))
+            kernel.magics.timer = (args['on'][0] == 'on')
+            kernel.magics.timer_profile = args['profile']
+            self.status = -1
+            return ''
+        except:
+            self.status = -1
+            return ''
 
 
 # ---------------------------------------------------------------------

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -83,8 +83,10 @@ class StataSession(object):
         self.mata_mode = False
         self.stata_prompt = '\r\n\. '
         self.stata_prompt_regex = r'\r\n(\x1b\[\?1h\x1b=)?\r\n\. '
+
         self.mata_prompt = '\r\n: '
         self.mata_prompt_regex = r'(\r\n|---+)(\x1b\[\?1h\x1b=)?\r\n: '
+
         self.prompt = self.stata_prompt
         self.prompt_regex = self.stata_prompt_regex
 
@@ -209,7 +211,6 @@ class StataSession(object):
             imgs = []
 
             for line in syn_chunks:
-                print('debugk0', line)
                 new_syn_chunks.append(line)
                 res, timer = self.do_console(line[1])
 
@@ -350,7 +351,6 @@ class StataSession(object):
             (int): execution time
         """
 
-        print('debugc0', line, self.prompt_regex)
         self.child.sendline(line)
         timer = default_timer()
         try:

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -226,10 +226,8 @@ class StataSession(object):
 
             for line in syn_chunks:
                 sleep(0.1)
-                # print('debugl', line)
                 new_syn_chunks.append(line)
                 res, timer = self.do_console(line[1])
-                # print('debugb', res)
 
                 log.append(res)
                 err = err_regex(res)
@@ -258,8 +256,6 @@ class StataSession(object):
 
             # Only full input allowed: If command ended in line
             # continuation, yell at the user.
-            # print('debugm', self.child.after, self.mata_bad_end(self.child.after))
-            # print('debugm', self.child.after)
             if self.mata_mode and self.child.after.endswith('> '):
                 rc = 3000
 
@@ -536,9 +532,7 @@ class StataSession(object):
         syn_chunks = syn_chunks[:len(log)]
 
         # Take out line continuations for both input and results
-        # print("debuglog0", log)
         log = [re.sub(r'\r\n> ', '', x) for x in log]
-        # print("debuglog1", log)
 
         log_all = []
         for (Token, code_line), log_line in zip(syn_chunks, log):
@@ -547,8 +541,6 @@ class StataSession(object):
                 # block, the first line should equal the text sent
                 # The assert is just a sanity check for now.
                 log_line = log_line.split('\r\n')
-                # print("debuglog2", code_line)
-                # print("debuglog3", log_line)
                 assert log_line[0] == code_line
                 log_all.extend(log_line[1:])
                 log_all.append('')

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -1,8 +1,9 @@
 import os
 import re
+import base64
+import hashlib
 import platform
 import subprocess
-import base64
 from pkg_resources import resource_filename
 
 from time import sleep
@@ -59,6 +60,7 @@ graph_keywords = r'\b(' + '|'.join(graph_keywords) + r')\b'
 class StataSession(object):
     def __init__(self):
 
+        self.timer_dict = {}
         adofile = resource_filename(
             'stata_kernel', os.path.join('ado', '_StataKernelCompletions.ado'))
         self.adodir = Path(adofile).resolve().parent
@@ -87,12 +89,17 @@ class StataSession(object):
 
         self.mata_mode = False
         self.stata_prompt = '\r\n\. '
-        self.stata_prompt_regex = r'\r\n(\x1b\[\?1h\x1b=)?\r\n\. '
+        # self.stata_prompt_regex = r'\r\n(\x1b\[\?1h\x1b=)?\r\n\. '
+        # re.compile(
+        #     r'(\r\n(\x1b\[\?1h\x1b=)?\r\n\. )|'
+        #     r'([\r\n]{1,2}\. \Z)', flags = re.MULTILINE)
+        self.stata_prompt_regex = r'[\r\n]{1,2}\. '
 
         self.mata_prompt = '[\r\n]{1,2}: '
-        self.mata_prompt_regex = re.compile(
-            r'(([\r\n]{1,2}|---+)(\x1b\[\?1h\x1b=)?[\r\n]{1,2}: )|'
-            r'([\r\n]{1,2}> \Z)', flags = re.MULTILINE)
+        # self.mata_prompt_regex = re.compile(
+        #     r'(([\r\n]{1,2}|---+)(\x1b\[\?1h\x1b=)?[\r\n]{1,2}: )|'
+        #     r'([\r\n]{1,2}> \Z)', flags = re.MULTILINE)
+        self.mata_prompt_regex = r'[\r\n]{1,2}[:\>] '
         self.mata_trim = re.compile(
             r'((\r\n|\r|\n)\s+?)?(\r\n|\r|\n)\Z', flags=re.MULTILINE)
 
@@ -215,6 +222,7 @@ class StataSession(object):
         # capture the exit code if surrounded by \r\n; I made it catch
         # either or both.
 
+        self._timer()
         time_total = 0
         time_profile = []
         if self.execution_mode == 'console':
@@ -224,10 +232,12 @@ class StataSession(object):
             new_syn_chunks = []
             imgs = []
 
+            self._timer('do_console')
+            self._timer('do_post')
             for line in syn_chunks:
-                sleep(0.1)
                 new_syn_chunks.append(line)
                 res, timer = self.do_console(line[1])
+                self._timer('do_console', append = True)
 
                 log.append(res)
                 err = err_regex(res)
@@ -236,7 +246,7 @@ class StataSession(object):
                     break
 
                 gr = re.search(graph_keywords, line[1]) and (graphs == 1)
-                if (str(line[0]) != 'Token.MatchingBracket.Other') and gr:
+                if (not str(line[0]).startswith('Token.MatchingBracket')) and gr:
 
                     rc, img, sc = self.get_current_graph(
                         'console', magics.img_metadata)
@@ -253,6 +263,8 @@ class StataSession(object):
                         time_profile += [(timer, line[1][:68] + ' ...')]
                     else:
                         time_profile += [(timer, line[1])]
+
+                self._timer('do_post', append = True)
 
             # Only full input allowed: If command ended in line
             # continuation, yell at the user.
@@ -274,8 +286,13 @@ class StataSession(object):
                 time_profile += [(time_total, '')]
                 magics.time_profile = time_profile
 
+            self._timer('do_post', append = True)
             return rc, imgs, self.clean_log_console(log, new_syn_chunks)
         else:
+            self._timer('do_log')
+            self._timer('do_automate')
+            self._timer('do_post')
+
             # Blocks will be sent through DoCommandAsync while everything else
             # will be sent through docommand
             log_path = self.cache_dir / '.stata_kernel_log.log'
@@ -286,6 +303,8 @@ class StataSession(object):
             if rc:
                 return rc, ''
 
+            self._timer('do_log', append = True)
+
             # Keep track of how many chunks have been executed
             new_syn_chunks = []
             imgs = []
@@ -295,8 +314,10 @@ class StataSession(object):
                 new_syn_chunks.append(line)
                 if str(line[0]) == 'Token.MatchingBracket.Other':
                     rc, timer = self.do_aut_async(line[1])
+                    self._timer('do_automate', append = True)
                 else:
                     rc, timer = self.do_aut_sync(line[1])
+                    self._timer('do_automate', append = True)
                     gr = re.search(graph_keywords, line[1]) and (graphs == 1)
                     if (not rc) and gr:
 
@@ -318,6 +339,8 @@ class StataSession(object):
                     else:
                         time_profile += [(timer, line[1])]
 
+                self._timer('do_post', append = True)
+
             # graphs = 2 is set by the %plot magic to check for the last
             # image after a code chunk
             if (not rc) and (graphs == 2):
@@ -328,10 +351,12 @@ class StataSession(object):
                     new_syn_chunks.append(sc)
                     imgs.append(img)
 
+            self._timer('do_post', append = True)
             self.automate('DoCommand', self._mata_escape('cap log close'))
             with open(log_path, 'r') as f:
                 log = f.read()
 
+            self._timer('do_log', append = True)
             # Only full input allowed: If command ended in line
             # continuation, yell at the user.
             if self.mata_mode and log.endswith('> '):
@@ -345,6 +370,7 @@ class StataSession(object):
                 time_profile += [(time_total, '')]
                 magics.time_profile = time_profile
 
+            self._timer('do_post', append = True)
             return rc, imgs, self.clean_log_aut(log, syn_chunks)
 
     def do_console(self, line):
@@ -376,14 +402,24 @@ class StataSession(object):
             (int): execution time
         """
 
-        self.child.sendline(line)
+        str_hash = "{0}{1}".format(default_timer(), line)
+        code_hash = hashlib.md5(str_hash.encode('utf-8')).hexdigest()
+        code_match = "`{0}'".format(code_hash)
+        hash_regex = r"({0})?{1}{0}".format(self.prompt_regex, code_match)
+        self.child.sendline(line + "\n" + code_match)
+        # self.child.sendline(line)
         timer = default_timer()
         try:
-            self.child.expect(self.prompt_regex, timeout=20)
+            # self.child.expect(self.prompt_regex, timeout=20)
+            self.child.expect(hash_regex, timeout=None)
         except KeyboardInterrupt:
             self.child.sendcontrol('c')
-            self.child.expect(self.prompt_regex, timeout=20)
+            self.child.sendline("\n" + code_match)
+            # self.child.expect(self.prompt_regex, timeout=20)
+            self.child.expect(hash_regex, timeout=None)
 
+        # print('debug1', self.child.before)
+        # print('debug2', self.child.after)
         delta = default_timer() - timer
         return ansi_escape.sub('', self.child.before), delta
 
@@ -536,6 +572,7 @@ class StataSession(object):
 
         log_all = []
         for (Token, code_line), log_line in zip(syn_chunks, log):
+            # if not str(Token).startswith('Token.MatchingBracket'):
             if str(Token) != 'Token.MatchingBracket.Other':
                 # Since I'm sending one line at a time, and since it's not a
                 # block, the first line should equal the text sent
@@ -784,3 +821,16 @@ class StataSession(object):
 
     def _mata_escape(self, line):
         return 'stata(`"{0}"\')'.format(line) if self.mata_mode else line
+
+    def _timer(self, step = None, append = False):
+        if step:
+            if append:
+                self.timer_dict[step] += default_timer() - self.timer_dict['timer']
+                self.timer_dict['timer'] = default_timer()
+            else:
+                self.timer_dict[step] = default_timer() - self.timer_dict['timer']
+                self.timer_dict['timer'] = default_timer()
+        else:
+            self.timer_dict = {}
+            self.timer_dict['all'] = default_timer()
+            self.timer_dict['timer'] = default_timer()


### PR DESCRIPTION
Rudimentary mata support. **not** ready to merge. Wanted to get input on the TODOs.

- [ ] closes #26 
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Features:
- `mata` enters mata, `end` exits.
- `*` de-references a pointer and is not a comment.
- `program` and `input` get sent instead of prompting a continuation.
- `while` and `for` loops work as expected and prompt continuation.
- `%status` magic prints delimit and mata status.

TODO:
- [x] Mata-aware completions once completions are merged to master
- [x] `#delimit ;` is not currently working.
- [x] `if` is not currently working.
- [x] Code gets out of sync on continuation error
- [x] If there are no superfluous lines the code hangs (as does the regular kernel)
