### PR TITLE
%help magic displays HTML help where supported.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include requirements.txt
 include requirements_dev.txt
 include LICENSE
 include stata_kernel/ado/*.ado
+include stata_kernel/css/*.css

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+beautifulsoup4>=4.6.3
 jupyter_client>=5.2.3
 IPython>=6.5.0
 ipykernel>=4.8.2
@@ -6,4 +7,3 @@ pillow>=5.2.0
 pexpect>=4.6.0
 pygments>=2.2.0
 regex>=2018.7.11
-bs4>=0.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pillow>=5.2.0
 pexpect>=4.6.0
 pygments>=2.2.0
 regex>=2018.7.11
+bs4>=0.0.1

--- a/stata_kernel/css/_StataKernelHelpDefault.css
+++ b/stata_kernel/css/_StataKernelHelpDefault.css
@@ -1,0 +1,31 @@
+h2 {
+    font-family: Arial,Helvetica,Helv,sans-serif;
+    color: #000000;
+}
+
+pre {
+    margin: 10px;
+}
+
+table {
+    background-color: transparent;
+    border-color: transparent;
+    bgcolor: transparent;
+}
+
+tr {
+    background-color: transparent;
+    border-color: transparent;
+    bgcolor: transparent;
+}
+
+body {
+    background-color: transparent;
+    border-color: transparent;
+    margin: 0px;
+}
+
+div {
+    background-color: transparent;
+    border-color: transparent;
+}

--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -1,8 +1,13 @@
 import sys
 import re
+import urllib
 import pandas as pd
+
+from pathlib import Path
 from argparse import ArgumentParser
+from bs4 import BeautifulSoup as bs
 from .code_manager import CodeManager
+from pkg_resources import resource_filename
 
 
 # NOTE(mauricio): Figure  out if passing the kernel around is a problem...
@@ -60,6 +65,8 @@ class MagicParsers():
 
 
 class StataMagics():
+    html_base = "https://www.stata.com"
+    html_help = urllib.parse.urljoin(html_base, "help.cgi?{}")
     img_metadata = {'width': 600, 'height': 400}
 
     magic_regex = re.compile(
@@ -67,6 +74,7 @@ class StataMagics():
 
     available_magics = [
         'browse',
+        'help',
         # 'exit',
         # 'restart',
         'locals',
@@ -74,6 +82,9 @@ class StataMagics():
         'delimit',
         'time',
         'timeit']
+
+    csshelp_default = resource_filename(
+        'stata_kernel', 'css/_StataKernelHelpDefault.css')
 
     def __init__(self):
         self.quit_early = None
@@ -260,6 +271,52 @@ class StataMagics():
         self.graphs = 0
         print_kernel("Magic timeit has not been implemented.", kernel)
         return code
+
+    def magic_help(self, code, kernel):
+        self.status = -1
+        self.graphs = 0
+        cmd = code.strip().replace(" ", "_")
+        try:
+            reply = urllib.request.urlopen(self.html_help.format(cmd))
+            html = reply.read().decode("utf-8")
+            soup = bs(html, 'html.parser')
+
+            # Set root for links to https://ww.stata.com
+            for a in soup.find_all('a', href = True):
+                href = a.get('href')
+                relative = href.find('#')
+                if relative >= 0:
+                    a['href'] = href[relative:]
+                elif not href.startswith('http'):
+                    a['href'] = urllib.parse.urljoin(self.html_base, href)
+
+            # Remove header 'Stata 15 help for ...'
+            soup.find('h2').decompose()
+
+            # Remove Stata help menu
+            soup.find('div', id = 'menu').decompose()
+
+            # Remove Copyright notice
+            soup.find('a', text = 'Copyright').parent.parent.decompose()
+
+            # Set all the backgrounds to transparent
+            for color in ['#ffffff', '#FFFFFF']:
+                for bg in ['bgcolor', 'background', 'background-color']:
+                    for tag in soup.find_all(attrs = {bg: color}):
+                        if tag.get(bg):
+                            tag[bg] = 'transparent'
+
+            # Set html
+            css = soup.find('style', {'type': 'text/css'})
+            with open(self.csshelp_default, 'r') as default:
+                css.string = default.read()
+
+            resp = {'data': {'text/html': str(soup)}, 'metadata': {},}
+            kernel.send_response(kernel.iopub_socket, 'display_data', resp)
+        except urllib.error.HTTPError as e:
+            print_kernel("Failed to fetch HTML help.\r\n" + e.code, kernel)
+
+        return ''
 
     def magic_exit(self, code, kernel):
         self.status = -1

--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -285,7 +285,8 @@ class StataMagics():
                 href = a.get('href')
                 relative = href.find(cmd + '#')
                 if relative >= 0:
-                    a['href'] = href[relative:]
+                    hrelative = href.find('#')
+                    a['href'] = href[hrelative:]
                 elif not href.startswith('http'):
                     a['href'] = urllib.parse.urljoin(self.html_base, href)
 

--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -3,7 +3,6 @@ import re
 import urllib
 import pandas as pd
 
-from pathlib import Path
 from argparse import ArgumentParser
 from bs4 import BeautifulSoup as bs
 from .code_manager import CodeManager
@@ -160,7 +159,7 @@ class StataMagics():
         df = pd.read_csv(kernel.conf.get('cache_dir') / 'data.csv')
         df.index += 1
         html = df.to_html(na_rep = '.', notebook=True)
-        content = {'data': {'text/html': html}, 'metadata': {},}
+        content = {'data': {'text/html': html}, 'metadata': {}}
         kernel.send_response(kernel.iopub_socket, 'display_data', content)
         self.status = -1
         return ''
@@ -311,7 +310,7 @@ class StataMagics():
             with open(self.csshelp_default, 'r') as default:
                 css.string = default.read()
 
-            resp = {'data': {'text/html': str(soup)}, 'metadata': {},}
+            resp = {'data': {'text/html': str(soup)}, 'metadata': {}}
             kernel.send_response(kernel.iopub_socket, 'display_data', resp)
         except urllib.error.HTTPError as e:
             print_kernel("Failed to fetch HTML help.\r\n" + e.code, kernel)
@@ -334,6 +333,7 @@ class StataMagics():
         self.status = -1
         print_kernel("Magic restart has not been implemented.", kernel)
         return code
+
 
 def print_kernel(msg, kernel):
     msg = re.sub(r'$', r'\r\n', msg, flags=re.MULTILINE)

--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -283,7 +283,7 @@ class StataMagics():
             # Set root for links to https://ww.stata.com
             for a in soup.find_all('a', href = True):
                 href = a.get('href')
-                relative = href.find('#')
+                relative = href.find(cmd + '#')
                 if relative >= 0:
                     a['href'] = href[relative:]
                 elif not href.startswith('http'):
@@ -296,7 +296,10 @@ class StataMagics():
             soup.find('div', id = 'menu').decompose()
 
             # Remove Copyright notice
-            soup.find('a', text = 'Copyright').parent.parent.decompose()
+            soup.find('a', text = 'Copyright').find_parent("table").decompose()
+
+            # Remove last hrule
+            soup.find_all('hr')[-1].decompose()
 
             # Set all the backgrounds to transparent
             for color in ['#ffffff', '#FFFFFF']:


### PR DESCRIPTION
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Fixes #86 

Adds %help magic that displays HTML help if supported (tested in Atom and Notebook).