### PR TITLE
Add example for unsupported graph commands

### DIFF
--- a/docs/src/using_stata_kernel/intro.md
+++ b/docs/src/using_stata_kernel/intro.md
@@ -10,6 +10,8 @@ After [installing](../getting_started.md) and optionally [configuring](../gettin
 
 To minimize false positives, the graph keyword must appear at the beginning of a line. To hide the display of a graph, just prefix `graph` with [`quietly`](https://www.stata.com/help.cgi?quietly).
 
+To display graphs from user created commands (e.g., `coefplot`), use `graph display` after the command that generated the graph.
+
 ## `#delimit ;` mode
 
 Stata lets you use [`;` as a command


### PR DESCRIPTION
User-developed stata commands that create graphs are currently not supported by stata_kernel because of the regex that is used to pick up graphs. Adding `graph display` after the user-developed command triggers the regex and correctly inserts the graph.