### PR TITLE
updated link to "getting started" guide

### DIFF
--- a/stata_kernel/install.py
+++ b/stata_kernel/install.py
@@ -48,7 +48,7 @@ def install_conf():
             WARNING: Could not find Stata path.
             Refer to the documentation to see how to set it manually:
 
-            https://kylebarron.github.io/stata_kernel/user_guide/configuration/
+            https://kylebarron.github.io/stata_kernel/getting_started/#configuration
 
             """
         print(dedent(msg))


### PR DESCRIPTION
The link to the guide that is shown when the Stata path can't be found was not correct anymore. This fixes this.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
