### PR TITLE
Some ado file fixes

### DIFF
--- a/stata_kernel/ado/_StataKernelCompletions.ado
+++ b/stata_kernel/ado/_StataKernelCompletions.ado
@@ -1,6 +1,5 @@
 capture program drop _StataKernelCompletions
 program _StataKernelCompletions
-    local userTrace `c(trace)'
     set more off
     set trace off
     syntax [varlist]
@@ -15,5 +14,4 @@ program _StataKernelCompletions
     disp `"`:all scalars'"'
     disp "%matrices%"
     disp `"`:all matrices'"'
-    set trace `userTrace'
 end

--- a/stata_kernel/ado/_StataKernelCompletions.ado
+++ b/stata_kernel/ado/_StataKernelCompletions.ado
@@ -1,6 +1,7 @@
 capture program drop _StataKernelCompletions
 program _StataKernelCompletions
     local userTrace `c(trace)'
+    set more off
     set trace off
     syntax [varlist]
     disp "%varlist%"

--- a/stata_kernel/ado/_StataKernelHead.ado
+++ b/stata_kernel/ado/_StataKernelHead.ado
@@ -7,7 +7,7 @@ program _StataKernelHead
     * First, parse the number of lines to print. Either the first 10 or
     * the number specified by the user.
 
-    if ( regexm(`"`anything'"', "^\s*([0-9]+)") ) {
+    if ( regexm(`"`anything'"', "^[ ]*([0-9]+)") ) {
         local n1 = regexs(1)
         gettoken n2 anything: anything
         cap assert `n1' == `n2'

--- a/stata_kernel/ado/_StataKernelHead.ado
+++ b/stata_kernel/ado/_StataKernelHead.ado
@@ -2,6 +2,7 @@ capture program drop _StataKernelHead
 program _StataKernelHead
     syntax [anything] [if] using, [*]
     set more off
+    set trace off
     if ( !`=_N > 0' ) error 2000
 
     * First, parse the number of lines to print. Either the first 10 or

--- a/stata_kernel/ado/_StataKernelHead.ado
+++ b/stata_kernel/ado/_StataKernelHead.ado
@@ -1,6 +1,7 @@
 capture program drop _StataKernelHead
 program _StataKernelHead
     syntax [anything] [if] using, [*]
+    set more off
     if ( !`=_N > 0' ) error 2000
 
     * First, parse the number of lines to print. Either the first 10 or

--- a/stata_kernel/ado/_StataKernelTail.ado
+++ b/stata_kernel/ado/_StataKernelTail.ado
@@ -2,6 +2,7 @@ capture program drop _StataKernelTail
 program _StataKernelTail
     syntax [anything] [if] using, [*]
     set more off
+    set trace off
     if ( !`=_N > 0' ) error 2000
 
     * First, parse the number of lines to print. Either the last 10 or

--- a/stata_kernel/ado/_StataKernelTail.ado
+++ b/stata_kernel/ado/_StataKernelTail.ado
@@ -7,7 +7,7 @@ program _StataKernelTail
     * First, parse the number of lines to print. Either the last 10 or
     * the number specified by the user.
 
-    if ( regexm(`"`anything'"', "^\s*([0-9]+)") ) {
+    if ( regexm(`"`anything'"', "^[ ]*([0-9]+)") ) {
         local n1 = regexs(1)
         gettoken n2 anything: anything
         cap assert `n1' == `n2'

--- a/stata_kernel/ado/_StataKernelTail.ado
+++ b/stata_kernel/ado/_StataKernelTail.ado
@@ -1,6 +1,7 @@
 capture program drop _StataKernelTail
 program _StataKernelTail
     syntax [anything] [if] using, [*]
+    set more off
     if ( !`=_N > 0' ) error 2000
 
     * First, parse the number of lines to print. Either the last 10 or


### PR DESCRIPTION
- [ ] closes #132 
- [ ] tests added / passed

@mcaceresb 
1. The `\s` is invalid with `regexm`; it can only be used with `ustrregexm`, but I don't want to impose Stata 14. I changed it to `[ ]*`.
2. Running `set more off` at the beginning of the do files should help to fix #132, though it doesn't fix the larger `more` parsing problem described in #103. Specifically, when the user loads a very wide dataset, when `more` is on and `pagesize` is set to whatever we currently have it set to, `more` breaks the `varlist` printed during `_StataKernelCompletions`. More generally, the dataset should (?) never be wide enough for `_StataKernelCompletions` to take too long(?).
2. It doesn't seem to me that the `set trace on` persists past program end, so we shouldn't need to record the user setting and return it to that state.
![image](https://user-images.githubusercontent.com/15164633/45129330-21a92280-b151-11e8-84a7-e48032d71e29.png)
This appears to be the case even on Stata 11:
![image](https://user-images.githubusercontent.com/15164633/45129333-2c63b780-b151-11e8-8616-326ba64cdd43.png)

