### PR TITLE
Newlines fixes

### DIFF
--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -258,9 +258,13 @@ class StataSession():
                 if res == '':
                     res += '\n'
                 if res:
-                    res_list.append(res)
-                if display and res:
                     res = ansi_escape.sub('', res)
+                    res_list.append(res)
+                if not ''.join(res_list).strip():
+                    continue
+                if display and res:
+                    if not ''.join(res_list[:-1]).strip():
+                        res = ''.join(res_list[:-1]) + res
                     self.kernel.send_response(
                         self.kernel.iopub_socket, 'stream', {
                             'text': res,

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -255,7 +255,7 @@ class StataSession():
                 break
             if match_index == 4:
                 code_lines, res = self.clean_log_eol(child, code_lines, res)
-                if res == '':
+                if res is not None:
                     res += '\n'
                 if res:
                     res = ansi_escape.sub('', res)
@@ -278,7 +278,7 @@ class StataSession():
         child.expect('\r?\n')
 
         # Remove line continuation markers in output returned internally
-        res = '\n'.join(res_list)
+        res = ''.join(res_list)
         res = res.replace('\n> ', '')
 
         return rc, res

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -255,14 +255,14 @@ class StataSession():
                 break
             if match_index == 4:
                 code_lines, res = self.clean_log_eol(child, code_lines, res)
-                if res is not None:
-                    res += '\n'
-                if res:
-                    res = ansi_escape.sub('', res)
-                    res_list.append(res)
-                if not ''.join(res_list).strip():
+                if res is None:
                     continue
-                if display and res:
+                res += '\n'
+                res = ansi_escape.sub('', res)
+                res_list.append(res)
+                if re.search(r'[^\r\n]\r?\n\r?\n$', ''.join(res_list)):
+                    continue
+                if display:
                     if not ''.join(res_list[:-1]).strip():
                         res = ''.join(res_list[:-1]) + res
                     self.kernel.send_response(

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -260,7 +260,7 @@ class StataSession():
                 res += '\n'
                 res = ansi_escape.sub('', res)
                 res_list.append(res)
-                if re.search(r'[^\r\n]\r?\n\r?\n$', ''.join(res_list)):
+                if not ''.join(res_list).strip():
                     continue
                 if display:
                     if not ''.join(res_list[:-1]).strip():

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -255,13 +255,15 @@ class StataSession():
                 break
             if match_index == 4:
                 code_lines, res = self.clean_log_eol(child, code_lines, res)
+                if res == '':
+                    res += '\n'
                 if res:
                     res_list.append(res)
                 if display and res:
                     res = ansi_escape.sub('', res)
                     self.kernel.send_response(
                         self.kernel.iopub_socket, 'stream', {
-                            'text': res + '\n',
+                            'text': res,
                             'name': 'stdout'})
                 continue
             if match_index == 5:

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -233,6 +233,7 @@ class StataSession():
 
         match_index = -1
         res_list = []
+        res_disp = ''
         rc = 0
         while match_index != 0:
             match_index = child.expect(expect_list, timeout=None)
@@ -259,19 +260,28 @@ class StataSession():
                     continue
                 res += '\n'
                 res = ansi_escape.sub('', res)
+                res_disp += res
                 res_list.append(res)
                 if not ''.join(res_list).strip():
                     continue
+                if not res_disp.strip():
+                    continue
                 if display:
-                    if not ''.join(res_list[:-1]).strip():
-                        res = ''.join(res_list[:-1]) + res
                     self.kernel.send_response(
                         self.kernel.iopub_socket, 'stream', {
-                            'text': res,
+                            'text': res_disp,
                             'name': 'stdout'})
+                    res_disp = ''
                 continue
             if match_index == 5:
                 sleep(0.05)
+
+        if display and res_disp:
+            self.kernel.send_response(
+                self.kernel.iopub_socket, 'stream', {
+                    'text': re.sub(r'\n\Z', '', res_disp, re.M),
+                    'name': 'stdout'})
+            res_disp = ''
 
         # Then scroll to next newline, but not including period to make it
         # easier to remove code lines later


### PR DESCRIPTION
- [x] closes #144, closes #111
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

- Keep empty newlines of output
- Don't return whitespace-only lines until a text character is found. This means that running `di _n(3)` will give no result. The reason for this is that it looks better in Hydrogen to have a check mark to represent the fact that a command finished with no material output, rather than seeing empty whitespace lines. For example:
![image](https://user-images.githubusercontent.com/15164633/45194742-5802a280-b222-11e8-99b9-0065e618a92e.png)


