### PR TITLE
 redirect `xstata` paths to `stata`

### DIFF
--- a/stata_kernel/config.py
+++ b/stata_kernel/config.py
@@ -23,7 +23,7 @@ class Config(object):
             if not self.get('execution_mode') in ['console', 'automation']:
                 self.raise_config_error('execution_mode')
         elif platform.system() == 'Linux':
-            self.set('stata_path', self.get_linux_stata_path_variant())
+            self.set('stata_path', self.get_linux_stata_path_variant(), permanent=True)
 
         if not self.get('stata_path'):
             self.raise_config_error('stata_path')

--- a/stata_kernel/config.py
+++ b/stata_kernel/config.py
@@ -1,3 +1,4 @@
+import re
 import platform
 
 from pathlib import Path
@@ -21,6 +22,8 @@ class Config(object):
             self.set('stata_path', self.get_mac_stata_path_variant())
             if not self.get('execution_mode') in ['console', 'automation']:
                 self.raise_config_error('execution_mode')
+        elif platform.system() == 'Linux':
+            self.set('stata_path', self.get_linux_stata_path_variant())
 
         if not self.get('stata_path'):
             self.raise_config_error('stata_path')
@@ -60,6 +63,20 @@ class Config(object):
 
         bin_name = d.get(path.name, path.name)
         return str(path.parent / bin_name)
+
+    def get_linux_stata_path_variant(self):
+        stata_path = self.get('stata_path')
+
+        d = {
+            'xstata': 'stata',
+            'xstata-se': 'stata-se',
+            'xstata-mp': 'stata-mp'}
+        for xname, name in d.items():
+            if stata_path.endswith(xname):
+                stata_path = re.sub(r'{}$'.format(xname), name, stata_path)
+                break
+
+        return stata_path
 
     def raise_config_error(self, option):
         msg = """\

--- a/stata_kernel/install.py
+++ b/stata_kernel/install.py
@@ -36,7 +36,7 @@ def install_conf():
         execution_mode = 'console'
         for i in ['stata-mp', 'StataMP', 'stata-se', 'StataSE', 'stata',
                   'Stata']:
-            stata_path = which('StataMP')
+            stata_path = which(i)
             if stata_path:
                 break
 


### PR DESCRIPTION
- [x] closes #149
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Also fixes use of `which` in the install script. Previously I hadn't been actually using the loop 😆 