### PR TITLE
Override pygments file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ include stata_kernel/docs/*html
 include stata_kernel/docs/*txt
 include stata_kernel/docs/using_stata_kernel/*html
 include stata_kernel/docs/using_stata_kernel/*txt
+include stata_kernel/pygments/stata.py

--- a/stata_kernel/kernel.py
+++ b/stata_kernel/kernel.py
@@ -1,9 +1,13 @@
 import base64
+import shutil
 import platform
 
 from PIL import Image
+from pathlib import Path
 from textwrap import dedent
+from datetime import datetime
 from xml.etree import ElementTree as ET
+from pkg_resources import resource_filename
 from ipykernel.kernelbase import Kernel
 
 from .config import Config
@@ -27,6 +31,22 @@ class StataKernel(Kernel):
     ] # yapf: disable
 
     def __init__(self, *args, **kwargs):
+        # Copy pygments file to Python location
+        pyg_path = Path(resource_filename('pygments', 'lexers/stata.py'))
+        pyg_path_sk = Path(
+            resource_filename('stata_kernel', 'pygments/stata.py'))
+        copy = False
+        if pyg_path.is_file():
+            pyg_path_dt = datetime.fromtimestamp(pyg_path.stat().st_mtime)
+            pyg_path_sk_dt = datetime.fromtimestamp(pyg_path_sk.stat().st_mtime)
+            if pyg_path_sk_dt > pyg_path_dt:
+                copy = True
+        else:
+            copy = True
+
+        if copy:
+            shutil.copy(str(pyg_path_sk), str(pyg_path))
+
         super(StataKernel, self).__init__(*args, **kwargs)
 
         # Can't name this `self.config`. Conflicts with a Jupyter attribute

--- a/stata_kernel/pygments/stata.py
+++ b/stata_kernel/pygments/stata.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+"""
+    pygments.lexers.stata
+    ~~~~~~~~~~~~~~~~~~~~~
+
+    Lexer for Stata
+
+    :copyright: Copyright 2006-2017 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import re
+from pygments.lexer import RegexLexer, include, words
+from pygments.token import Comment, Keyword, Name, Number, \
+    String, Text, Operator
+
+from pygments.lexers._stata_builtins import builtins_base, builtins_functions
+
+__all__ = ['StataLexer']
+
+
+class StataLexer(RegexLexer):
+    """
+    For `Stata <http://www.stata.com/>`_ do files.
+
+    .. versionadded:: 2.2
+    """
+    # Syntax based on
+    # - http://fmwww.bc.edu/RePEc/bocode/s/synlightlist.ado
+    # - http://github.com/isagalaev/highlight.js/blob/master/src/languages/stata.js
+    # - http://github.com/jpitblado/vim-stata/blob/master/syntax/stata.vim
+
+    name      = 'Stata'
+    aliases   = ['stata', 'do']
+    filenames = ['*.do', '*.ado']
+    mimetypes = ['text/x-stata', 'text/stata', 'application/x-stata']
+    flags = re.MULTILINE | re.DOTALL
+
+    tokens = {
+        'root': [
+            include('comments'),
+            include('strings'),
+            include('macros'),
+            include('numbers'),
+            include('keywords'),
+            include('operators'),
+            include('format'),
+            (r'.', Text),
+        ],
+        # Comments are a complicated beast in Stata because they can be
+        # nested and there are a few corner cases with that. See:
+        # - github.com/kylebarron/language-stata/issues/90
+        # - statalist.org/forums/forum/general-stata-discussion/general/1448244
+        'comments': [
+            (r'(^//|(?<=\s)//)(?!/)', Comment.Single, 'comments-double-slash'),
+            (r'^\s*\*', Comment.Single, 'comments-star'),
+            (r'/\*', Comment.Multiline, 'comments-block'),
+            (r'(^///|(?<=\s)///)', Comment.Special, 'comments-triple-slash')
+        ],
+        'comments-block': [
+            (r'/\*', Comment.Multiline, '#push'),
+            # this ends and restarts a comment block. but need to catch this so
+            # that it doesn\'t start _another_ level of comment blocks
+            (r'\*/\*', Comment.Multiline),
+            (r'(\*/\s+\*(?!/)[^\n]*)|(\*/)', Comment.Multiline, '#pop'),
+            # Match anything else as a character inside the comment
+            (r'.', Comment.Multiline),
+        ],
+        'comments-star': [
+            (r'///.*?\n', Comment.Single,
+                ('#pop', 'comments-triple-slash')),
+            (r'(^//|(?<=\s)//)(?!/)', Comment.Single,
+                ('#pop', 'comments-double-slash')),
+            (r'/\*', Comment.Multiline, 'comments-block'),
+            (r'.(?=\n)', Comment.Single, '#pop'),
+            (r'.', Comment.Single),
+        ],
+        'comments-triple-slash': [
+            (r'\n', Comment.Special, '#pop'),
+            # A // breaks out of a comment for the rest of the line
+            (r'//.*?(?=\n)', Comment.Single, '#pop'),
+            (r'.', Comment.Special),
+        ],
+        'comments-double-slash': [
+            (r'\n', Text, '#pop'),
+            (r'.', Comment.Single),
+        ],
+        # `"compound string"' and regular "string"; note the former are
+        # nested.
+        'strings': [
+            (r'`"', String, 'string-compound'),
+            (r'(?<!`)"', String, 'string-regular'),
+        ],
+        'string-compound': [
+            (r'`"', String, '#push'),
+            (r'"\'', String, '#pop'),
+            (r'\\\\|\\"|\\\$|\\`|\\\n', String.Escape),
+            include('macros'),
+            (r'.', String)
+        ],
+        'string-regular': [
+            (r'(")(?!\')|(?=\n)', String, '#pop'),
+            (r'\\\\|\\"|\\\$|\\`|\\\n', String.Escape),
+            include('macros'),
+            (r'.', String)
+        ],
+        # A local is usually
+        #     `\w{0,31}'
+        #     `:extended macro'
+        #     `=expression'
+        #     `[rsen](results)'
+        #     `(++--)scalar(++--)'
+        #
+        # However, there are all sorts of weird rules wrt edge
+        # cases. Instead of writing 27 exceptions, anything inside
+        # `' is a local.
+        #
+        # A global is more restricted, so we do follow rules. Note only
+        # locals explicitly enclosed ${} can be nested.
+        'macros': [
+            (r'\$(\{|(?=[\$`]))', Name.Variable.Global, 'macro-global-nested'),
+            (r'\$', Name.Variable.Global,  'macro-global-name'),
+            (r'`', Name.Variable, 'macro-local'),
+        ],
+        'macro-local': [
+            (r'`', Name.Variable, '#push'),
+            (r"'", Name.Variable, '#pop'),
+            (r'\$(\{|(?=[\$`]))', Name.Variable.Global, 'macro-global-nested'),
+            (r'\$', Name.Variable.Global, 'macro-global-name'),
+            (r'.', Name.Variable),  # fallback
+        ],
+        'macro-global-nested': [
+            (r'\$(\{|(?=[\$`]))', Name.Variable.Global, '#push'),
+            (r'\}', Name.Variable.Global, '#pop'),
+            (r'\$', Name.Variable.Global, 'macro-global-name'),
+            (r'`', Name.Variable, 'macro-local'),
+            (r'\w', Name.Variable.Global),  # fallback
+            (r'(?!\w)', Name.Variable.Global, '#pop'),
+        ],
+        'macro-global-name': [
+            (r'\$(\{|(?=[\$`]))', Name.Variable.Global, 'macro-global-nested', '#pop'),
+            (r'\$', Name.Variable.Global, 'macro-global-name', '#pop'),
+            (r'`', Name.Variable, 'macro-local', '#pop'),
+            (r'\w{1,32}', Name.Variable.Global, '#pop'),
+        ],
+        # Built in functions and statements
+        'keywords': [
+            (words(builtins_functions, prefix = r'\b', suffix = r'(?=\()'),
+             Name.Function),
+            (words(builtins_base, prefix = r'(^\s*|\s)', suffix = r'\b'),
+             Keyword),
+        ],
+        # http://www.stata.com/help.cgi?operators
+        'operators': [
+            (r'-|==|<=|>=|<|>|&|!=', Operator),
+            (r'\*|\+|\^|/|!|~|==|~=', Operator)
+        ],
+        # Stata numbers
+        'numbers': [
+            # decimal number
+            (r'\b[+-]?([0-9]+(\.[0-9]+)?|\.[0-9]+|\.)([eE][+-]?[0-9]+)?[i]?\b',
+             Number),
+        ],
+        # Stata formats
+        'format': [
+            (r'%-?\d{1,2}(\.\d{1,2})?[gfe]c?', Name.Format),
+            (r'%(21x|16H|16L|8H|8L)', Name.Format),
+            (r'%-?(tc|tC|td|tw|tm|tq|th|ty|tg).{0,32}', Name.Format),
+            (r'%[-~]?\d{1,4}s', Name.Format),
+        ]
+    }


### PR DESCRIPTION
- [x] closes #164 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

- This overwrites the Stata lexer installed with Pygments. If there are multiple Python installations on the system, this might not work.
- It's not put in `install.py` because I don't expect users to run that again when upgrading.
- I'm not sure if it has to be before `super`. Maybe it would be better if it isn't?