### PR TITLE
Add PDF graph support

### DIFF
--- a/stata_kernel/code_manager.py
+++ b/stata_kernel/code_manager.py
@@ -220,6 +220,7 @@ class CodeManager(object):
             use_include = True
 
         # Insert `graph export`
+        # TODO: Instead of if/else, just add fallbacks to .get()
         graph_fmt = config.get('graph_format')
         graph_scale = config.get('graph_scale')
         graph_width = config.get('graph_width')
@@ -240,6 +241,8 @@ class CodeManager(object):
         if graph_height:
             graph_height = int(graph_height)
             dim_str += " height({})".format(int(graph_height * graph_scale))
+        if graph_fmt == 'pdf':
+            dim_str = ''
 
         cache_dir_str = str(cache_dir)
         if platform.system() == 'Windows':

--- a/stata_kernel/kernel.py
+++ b/stata_kernel/kernel.py
@@ -58,7 +58,7 @@ class StataKernel(Kernel):
 
         # Can't name this `self.config`. Conflicts with a Jupyter attribute
         self.conf = Config()
-        self.graph_formats = ["svg", "png"]
+        self.graph_formats = ['svg', 'png', 'pdf']
         self.sc_delimit_mode = False
         self.stata = StataSession(self, self.conf)
         self.banner = self.stata.banner
@@ -195,6 +195,15 @@ class StataKernel(Kernel):
                     'image/png': {
                         'width': width,
                         'height': height}}}
+            self.send_response(self.iopub_socket, 'display_data', content)
+        elif graph_path.endswith('.pdf'):
+            with open(graph_path, 'rb') as f:
+                pdf = base64.b64encode(f.read()).decode('utf-8')
+            content = {
+                'data': {
+                    'text/plain': no_display_msg,
+                    'application/pdf': pdf},
+                'metadata': {}}
             self.send_response(self.iopub_socket, 'display_data', content)
 
     def do_shutdown(self, restart):

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -226,8 +226,9 @@ class StataSession():
         if platform.system() == 'Windows':
             cache_dir_str = re.sub(r'\\', '/', cache_dir_str)
 
+        # TODO: Use kernel.graph_formats instead of hard coding them
         g_exp = r'\(file ({}'.format(cache_dir_str)
-        g_exp += r'/graph\d+\.(svg|png)) written in (?i:(svg|png)) format\)'
+        g_exp += r'/graph\d+\.(svg|png|pdf)) written in (?i:(svg|png|pdf)) format\)'
 
         more = r'^--more--'
         eol = r'\r?\n'


### PR DESCRIPTION
- Very helpful when exporting to a LaTeX PDF. 

- [x] closes #170
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

It's not ideal for viewing in the notebook. It just has a link to open the PDF image in a new tab.
![image](https://user-images.githubusercontent.com/15164633/45531342-5f472480-b7bd-11e8-9d7e-31f41b6ee565.png)

Interestingly, the entire data of the PDF is encoded in the address bar.
![image](https://user-images.githubusercontent.com/15164633/45531378-89004b80-b7bd-11e8-9aaa-a6b872967898.png)

But it's incredibly helpful that it offers 1-click export to LaTeX PDF. For obvious reasons, SVG isn't ideal for PDF export because it has to be converted before LaTeX. PNG isn't ideal because Stata console on Linux can't create it. Thus I think PDF support is essential.
![image](https://user-images.githubusercontent.com/15164633/45531339-58b8ad00-b7bd-11e8-9de2-bea554c3c74e.png)
