### PR TITLE
PDF Graph redundancy

### DIFF
--- a/docs/src/using_stata_kernel/intro.md
+++ b/docs/src/using_stata_kernel/intro.md
@@ -12,6 +12,34 @@ To minimize false positives, the graph keyword must appear at the beginning of a
 
 To display graphs from user created commands (e.g., `coefplot`), use `graph display` after the command that generated the graph.
 
+### Graph display format
+
+`stata_kernel` must export the image in some format in order to load and display it. Sadly, there are considerable pros and cons to each image format:
+
+- `png` files can't be created with the console version of Stata, and thus are off limits to the Linux and Mac (console) modes of `stata_kernel`. Additionally, they can look pixelated when scaled up.
+- `svg` files can be created by Stata 14 and 15 on all platforms, and look crisp at all sizes, but can't be used with LaTeX PDF output.
+- `pdf` files can be created by all recent versions of Stata on all platforms, look crisp at all sizes, and work in LaTeX PDF output, but can't display in Jupyter.
+- `tif` files are too large.
+
+`stata_kernel` lets you set the display format to be `png`, `svg`, or `pdf`.
+
+### Graph redundancy
+
+One of the many amazing things about Jupyter Notebooks is that with a single click, you can export the notebook to an aesthetic PDF using LaTeX.
+
+Except on Windows using Stata 14 or earlier, `stata_kernel` displays images in `svg` format by default. However, as [noted above](#graph-display-format), these images can't be included in a LaTeX PDF export without conversion.
+
+To solve this problem, `stata_kernel` has the ability to hand Jupyter _both_ the `svg` or `png` version of an image _and_ the `pdf` version of the same image. While only the former will be displayed, the `pdf` version of the image will be stored in the Notebook and used when exported to PDF.
+
+While ease of use with LaTeX on macOS and Linux is a significant benefit, this redundancy does make `stata_kernel` delay slightly when displaying an image and enlarges the Jupyter Notebook file size (because two formats of every image will be stored within the Jupyter Notebook file).
+
+To turn off graph redundancy, change both configuration options to False:
+
+- `graph_svg_redundancy`: Whether to provide redundant PDF images when `svg` is the display format. `True` by default.
+- `graph_png_redundancy`: Whether to provide redundant PDF images when `png` is the display format. `False` by default.
+
+Because both image formats will be stored within the Jupyter Notebook file, `stata_kernel` will warn you if graph redundancy is on and an image is larger than 2 megabytes. To turn off this warning, set `graph_redundancy_warning` to `False`.
+
 ## `#delimit ;` mode
 
 Stata lets you use [`;` as a command

--- a/stata_kernel/config.py
+++ b/stata_kernel/config.py
@@ -13,7 +13,10 @@ class Config(object):
         'execution_mode',
         'graph_format',
         'graph_height',
+        'graph_png_redundancy',
+        'graph_redundancy_warning',
         'graph_scale',
+        'graph_svg_redundancy',
         'graph_width',
         'stata_path', ]  # yapf: ignore
 

--- a/stata_kernel/kernel.py
+++ b/stata_kernel/kernel.py
@@ -218,7 +218,7 @@ class StataKernel(Kernel):
         ```
 
         For more information, see:
-        <https://kylebarron.github.io/stata_kernel/test>
+        <https://kylebarron.github.io/stata_kernel/using_stata_kernel/intro/#graph-redundancy>
         """
         msg = dedent(msg)
         warn_setting = self.config.get('graph_redundancy_warning', 'True')

--- a/stata_kernel/kernel.py
+++ b/stata_kernel/kernel.py
@@ -144,23 +144,16 @@ class StataKernel(Kernel):
     def send_image(self, graph_paths):
         """Load graph and send to frontend
 
-        In `code_manager.get_text`, I send to Stata only the `width` argument.
-        This way, the graphs are always scaled in accordance with their aspect
-        ratio. However this means that I don't know their aspect ratio. For this
-        reason, I load the SVG or PNG image into memory so that I can get the
-        image dimensions to relay to the frontend.
-
-        As of now, this only supports SVG and PNG formats. I see no real need to
-        change this. PDF isn't supported in Atom or in Jupyter. TIFF is 1-2
-        orders of magnitude larger than SVG and PNG images without a real
-        benefit over SVG.
+        This supports SVG, PNG, and PDF formats. While PDF display isn't
+        supported in Atom or Jupyter, the data can be stored within the Jupyter
+        Notebook file and makes exporting images to PDF through LaTeX easier.
 
         Args:
             graph_paths (List[str]): path to exported graph
         """
 
         no_display_msg = 'This front-end cannot display the desired image type.'
-        content = {'data': {'text/plan': no_display_msg}, 'metadata': {}}
+        content = {'data': {'text/plain': no_display_msg}, 'metadata': {}}
         warn = False
         for graph_path in graph_paths:
             file_size = Path(graph_path).stat().st_size
@@ -222,8 +215,7 @@ class StataKernel(Kernel):
         """
         msg = dedent(msg)
         warn_setting = self.config.get('graph_redundancy_warning', 'True')
-        warn_setting = warn_setting.lower() == 'true'
-        if warn and warn_setting:
+        if warn and (warn_setting.lower() == 'true'):
             self.send_response(
                 self.iopub_socket, 'display_data', {
                     'data': {

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -269,8 +269,20 @@ class StataSession():
                             'name': 'stderr'})
                 continue
             if match_index == 2:
+                g_path = [child.match.group(1)]
+                g_fmt = child.match.group(2)
+                if g_fmt == 'svg':
+                    pdf_dup = self.config.get('graph_svg_redundancy', 'True')
+                elif g_fmt == 'png':
+                    pdf_dup = self.config.get('graph_png_redundancy', 'False')
+                pdf_dup = pdf_dup.lower() == 'true'
+
+                if pdf_dup:
+                    child.expect(g_exp, timeout=None)
+                    code_lines = code_lines[1:]
+                    g_path.append(child.match.group(1))
                 if display:
-                    self.kernel.send_image(child.match.group(1))
+                    self.kernel.send_image(g_path)
             if match_index == 3:
                 self.send_break(child=child, md5=md5[2:])
                 child.expect_exact(md5, timeout=None)


### PR DESCRIPTION
- [x] closes #175
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This returns the PDF along with the SVG by default, with the redundancy for PNGs off by default. It warns the user if one of the graph file sizes are more than 2MiB in size.