### PR TITLE
Simplify %set magic

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -4,7 +4,7 @@ It doesn't take much to get `stata_kernel` up and running. Here's how:
 
 ## Prerequisites
 
-- **Python**. In order to install the kernel, Python >= 3.5 needs to be installed on the computer on which Stata is running.
+- **Python**. In order to install the kernel, Python 3.5, 3.6, or 3.7 needs to be installed on the computer on which Stata is running.
 
     I suggest installing the [Anaconda
     distribution](https://www.anaconda.com/download/), which doesn't require
@@ -13,8 +13,7 @@ It doesn't take much to get `stata_kernel` up and running. Here's how:
     The Anaconda installer includes many third party libraries for Python that
     `stata_kernel` doesn't use. If you don't plan to use Python and want to use
     less disk space, install [Miniconda](https://conda.io/miniconda.html), which
-    includes few packages other than Python. Then in [Package
-    Install](#package-install) any other necessary dependencies will be
+    includes few packages other than Python. Then when [installing the package](#package-install) any other necessary dependencies will be
     downloaded automatically.
 
 
@@ -73,6 +72,14 @@ changing the `value` of any line of the form
 configuration_setting = value
 ```
 
+You can also make changes to the configuration while the kernel is running with the [%set magic](using_stata_kernel/magics.md#set). For example:
+
+```
+%set autocomplete_closing_symbol False
+%set graph_format png
+```
+
+
 ### General settings
 
 - `stata_path`: a string; the path on your file system to your Stata executable. Usually this can be found automatically in the [install step](getting_started.md#package-install), but sometimes may need to be set manually.
@@ -94,14 +101,7 @@ configuration_setting = value
 
 ### Graph settings
 
-These settings can be changed during a session with the `%set` magic, like so:
-
-```
-%set graph --format svg
-%set graph --scale 1
-%set graph --width 500
-%set graph --width 400 --height 300
-```
+These settings determine how graphs are displayed internally.
 
 - `graph_format`: `svg` or `png`, the format to export and display graphs. By default this is `svg` for most operating systems and versions of Stata, but is `png` by default for Windows on Stata 14 and below.
 

--- a/docs/src/using_stata_kernel/magics.md
+++ b/docs/src/using_stata_kernel/magics.md
@@ -133,18 +133,25 @@ S_MACH:    PC (64-bit x86-64)
 
 ## `%set`
 
-**Set configuration settings**
+**Set configuration value**
 
 Usage:
 ```
-%set [-h] [--permanently] [--reset] {graph,_all} ...
+%set [-h] [--permanently] [--reset] key value
 ```
 
+- `key`: Configuration key name. The full list of configuration options is shown on the [Getting Started](../getting_started.md#configuration) page.
+- `value`: Value to set.
+- `--permanently`: Store settings permanently.
+- `--reset`: Restore default settings.
+
+As an example, you can change the graph settings like so:
+
 ```
-%set graph --format svg
-%set graph --scale 1
-%set graph --width 500
-%set graph --width 400 --height 300
+%set graph_format svg --permanently
+%set graph_scale 1
+%set graph_width 500
+%set graph_height 300
 ```
 
 <!-- ## `%time`

--- a/stata_kernel/completions.py
+++ b/stata_kernel/completions.py
@@ -68,12 +68,12 @@ class CompletionsManager(object):
 
         self.suggestions = self.get_suggestions(kernel)
         self.suggestions['magics'] = kernel.magics.available_magics
-        self.suggestions['magics_set'] = kernel.magics.parse.set_settings
+        self.suggestions['magics_set'] = kernel.conf.all_settings
 
     def refresh(self, kernel):
         self.suggestions = self.get_suggestions(kernel)
         self.suggestions['magics'] = kernel.magics.available_magics
-        self.suggestions['magics_set'] = kernel.magics.parse.set_settings
+        self.suggestions['magics_set'] = kernel.conf.all_settings
 
     def get_env(self, code, rdelimit, sc_delimit_mode):
         """Returns completions environment

--- a/stata_kernel/completions.py
+++ b/stata_kernel/completions.py
@@ -200,7 +200,9 @@ class CompletionsManager(object):
             # scalar context.
             env += env_add
 
-        if not self.config.get('autocomplete_closing_symbol', False):
+        closing_symbol = self.config.get('autocomplete_closing_symbol', 'False')
+        closing_symbol = closing_symbol.lower() == 'true'
+        if not closing_symbol:
             rcomp = ''
 
         return env, pos, code[pos:], rcomp

--- a/stata_kernel/config.py
+++ b/stata_kernel/config.py
@@ -7,6 +7,16 @@ from configparser import ConfigParser
 
 
 class Config(object):
+    all_settings = [
+        'autocomplete_closing_symbol',
+        'cache_directory',
+        'execution_mode',
+        'graph_format',
+        'graph_height',
+        'graph_scale',
+        'graph_width',
+        'stata_path', ]  # yapf: ignore
+
     def __init__(self):
         self.config_path = Path('~/.stata_kernel.conf').expanduser()
         self.config = ConfigParser()
@@ -23,7 +33,9 @@ class Config(object):
             if not self.get('execution_mode') in ['console', 'automation']:
                 self.raise_config_error('execution_mode')
         elif platform.system() == 'Linux':
-            self.set('stata_path', self.get_linux_stata_path_variant(), permanent=True)
+            self.set(
+                'stata_path', self.get_linux_stata_path_variant(),
+                permanent=True)
 
         if not self.get('stata_path'):
             self.raise_config_error('stata_path')

--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -128,37 +128,15 @@ class MagicParsers():
         #                                                                     #
         #######################################################################
 
-        self.set = StataParser(prog='%set', kernel=kernel)
+        self.set = StataParser(prog='%set', kernel=kernel, description='Set configuration value.')
+        self.set.add_argument('key', type=str, help='Configuration key name.')
+        self.set.add_argument('value', type=str, help='Value to set.')
         self.set.add_argument(
             '--permanently', dest='perm', action='store_true',
             help="Store settings permanently", required=False)
         self.set.add_argument(
             '--reset', dest='reset', action='store_true',
             help="Restore default settings.", required=False)
-        subparsers = self.set.add_subparsers(
-            dest="setting", help=None, title="settings", description=None,
-            parser_class=StataParser)
-
-        self.set_graph = subparsers.add_parser(
-            "graph", kernel=kernel, help="Graph settings")
-        self.set_graph.add_argument(
-            '--scale', dest='scale', type=float, metavar='SCALE', default=None,
-            help="Scale width and height. Default: 1", required=False)
-        self.set_graph.add_argument(
-            '--width', dest='width', type=int, metavar='WIDTH', default=None,
-            help="Graph width (pixels). Default: 600", required=False)
-        self.set_graph.add_argument(
-            '--height', dest='height', type=int, metavar='HEIGHT', default=None,
-            help="Graph height (pixels). Default: Set by Stata.", required=False)
-        self.set_graph.add_argument(
-            '--format', dest='format', type=str, default=None,
-            choices=kernel.graph_formats, required=False,
-            metavar='{{{0}}}'.format('|'.join(kernel.graph_formats)),
-            help="Internal graph display format (default: svg).")
-
-        self.set_settings = list(subparsers.choices.keys())
-        self.set__all = subparsers.add_parser(
-            "_all", kernel=kernel, help="all settings")
 
 
 class StataMagics():
@@ -447,42 +425,24 @@ class StataMagics():
         try:
             settings = code.strip().split(' ')
             args = vars(self.parse.set.parse_args(settings))
+            key = args['key']
+            value = args['value']
             perm = args['perm']
             reset = args['reset']
-            setting = args['setting']
-            args.pop('reset', None)
-            args.pop('perm', None)
-            args.pop('setting', None)
 
-            if setting == 'graph':
-                if reset:
-                    for k, v in args.items():
-                        if v is not None:
-                            msg = 'Cannot set values with --reset.'
-                            self.parse.set.error(msg)
+            if reset:
+                if value is not None:
+                    msg = 'Cannot set values with --reset.'
+                    self.parse.set.error(msg)
 
-                    # reset graph settings
-                    kernel.conf.set('graph_format', 'svg', permanent=perm)
-                    kernel.conf.set('graph_scale', '1', permanent=perm)
-                    kernel.conf._remove_unsafe('graph_width', permanent=perm)
-                    kernel.conf._remove_unsafe('graph_height', permanent=perm)
-                else:
-                    for k, v in args.items():
-                        if v is not None:
-                            if k in ['width', 'height', 'scale'] and v <= 0:
-                                msg = '{0} should be positive; value: {1}'
-                                self.parse.set_graph.error(msg.format(k, v))
-
-                            kernel.conf.set('graph_' + k, v, permanent=perm)
-            elif setting == '_all':
-                if reset:
-                    # reset graph settings
-                    kernel.conf.set('graph_format', 'svg', permanent=perm)
-                    kernel.conf.set('graph_scale', '1', permanent=perm)
-                    kernel.conf._remove_unsafe('graph_width', permanent=perm)
-                    kernel.conf._remove_unsafe('graph_height', permanent=perm)
+                # reset graph settings
+                kernel.conf.set('graph_format', 'svg', permanent=perm)
+                kernel.conf.set('graph_scale', '1', permanent=perm)
+                kernel.conf._remove_unsafe('graph_width', permanent=perm)
+                kernel.conf._remove_unsafe('graph_height', permanent=perm)
             else:
-                self.parse.set.error('malformed %set call')
+                kernel.conf.set(key, value, permanent=perm)
+
         except:
             pass
 


### PR DESCRIPTION
- [ ] closes #182
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

@mcaceresb Can you test this out, since this changes your code?

Instead of bifurcating `%set` into `%set graph ...` and `%set _all ...`, this uses just `%set key value [--permanently] [--reset]`. I think this is simpler for the user and simpler to manage.

This also changes the autocompletions for `%set` to use the list of setting names.