### PR TITLE
Catch EOF when expecting for PDF graph copy

### DIFF
--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -280,7 +280,12 @@ class StataSession():
                 pdf_dup = pdf_dup.lower() == 'true'
 
                 if pdf_dup:
-                    child.expect(g_exp, timeout=None)
+                    while True:
+                        ind = child.expect([g_exp, pexpect.EOF], timeout=None)
+                        if ind == 0:
+                            break
+                        sleep(0.1)
+
                     code_lines = code_lines[1:]
                     g_path.append(child.match.group(1))
                 if display:


### PR DESCRIPTION
- [x] closes #192

I forgot about EOF happening in `fdpexpect`. This fixes graphs when graph redundancy is on.