### PR TITLE
Fix Python 3.5 support

### DIFF
--- a/stata_kernel/code_manager.py
+++ b/stata_kernel/code_manager.py
@@ -267,7 +267,7 @@ class CodeManager(object):
         hash_text = hashlib.md5(text.encode('utf-8')).hexdigest()
         text_to_exclude = text
         if use_include:
-            with open(cache_dir / 'include.do', 'w', encoding='utf-8') as f:
+            with (cache_dir / 'include.do').open('w', encoding='utf-8') as f:
                 f.write(text + '\n')
             text = "include {}/include.do".format(cache_dir_str)
             text_to_exclude = text + '\n' + text_to_exclude

--- a/stata_kernel/config.py
+++ b/stata_kernel/config.py
@@ -24,7 +24,7 @@ class Config(object):
     def __init__(self):
         self.config_path = Path('~/.stata_kernel.conf').expanduser()
         self.config = ConfigParser()
-        self.config.read(self.config_path)
+        self.config.read(str(self.config_path))
 
         self.env = dict(self.config.items('stata_kernel'))
         self.env['cache_dir'] = Path(

--- a/stata_kernel/install.py
+++ b/stata_kernel/install.py
@@ -90,7 +90,7 @@ def install_conf():
     user_graph_keywords = vioplot
     """.format(stata_path, execution_mode))
 
-    with open(Path('~/.stata_kernel.conf').expanduser(), 'w') as f:
+    with Path('~/.stata_kernel.conf').expanduser().open('w') as f:
         f.write(conf_default)
 
 

--- a/stata_kernel/kernel.py
+++ b/stata_kernel/kernel.py
@@ -173,7 +173,7 @@ class StataKernel(Kernel):
                 warn = True
 
             if graph_path.endswith('.svg'):
-                with open(graph_path, 'r', encoding='utf-8') as f:
+                with Path(graph_path).open('r', encoding='utf-8') as f:
                     img = f.read()
                 e = ET.ElementTree(ET.fromstring(img))
                 root = e.getroot()
@@ -193,7 +193,7 @@ class StataKernel(Kernel):
                 if platform.system() == 'Darwin':
                     width /= 2
                     height /= 2
-                with open(graph_path, 'rb') as f:
+                with Path(graph_path).open('rb') as f:
                     img = base64.b64encode(f.read()).decode('utf-8')
 
                 content['data']['image/png'] = img
@@ -202,7 +202,7 @@ class StataKernel(Kernel):
                     'height': height}
 
             elif graph_path.endswith('.pdf'):
-                with open(graph_path, 'rb') as f:
+                with Path(graph_path).open('rb') as f:
                     pdf = base64.b64encode(f.read()).decode('utf-8')
                 content['data']['application/pdf'] = pdf
 

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -245,8 +245,10 @@ class StataSession():
 
         g_exp = r'\(file ({}'.format(self.cache_dir_str)
         g_fmts = '|'.join(self.kernel.graph_formats)
-        g_exp += r'/graph\d+\.({0})) written in (?i:({0})) format\)'.format(
-            g_fmts)
+        g_exp += r'/graph\d+\.({0})) written in ({0}) format\)'.format(g_fmts)
+        # Ignore case for SVG/PDF/PNG
+        # This is not a `(?i:)` flag to support Python 3.5
+        g_exp = re.compile(g_exp, re.IGNORECASE)
 
         more = r'^--more--'
         eol = r'\r?\n'
@@ -272,7 +274,7 @@ class StataSession():
                 continue
             if match_index == 2:
                 g_path = [child.match.group(1)]
-                g_fmt = child.match.group(2)
+                g_fmt = child.match.group(2).lower()
                 if g_fmt == 'svg':
                     pdf_dup = self.config.get('graph_svg_redundancy', 'True')
                 elif g_fmt == 'png':

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -129,9 +129,9 @@ class StataSession():
             codec_errors='replace')
         self.child.setwinsize(100, 255)
         self.child.delaybeforesend = None
-        self.child.logfile = open(
-            self.config.get('cache_dir') / 'console_debug.log', 'w',
-            encoding='utf-8')
+        self.child.logfile = (
+            self.config.get('cache_dir') / 'console_debug.log').open(
+                'w', encoding='utf-8')
         banner = []
         try:
             self.child.expect('\r\n\. ', timeout=0.2)
@@ -174,7 +174,7 @@ class StataSession():
         if rc:
             return rc
 
-        self.fd = open(log_path)
+        self.fd = Path(log_path).open()
         if platform.system() == 'Windows':
             self.log_fd = pexpect.fdpexpect.fdspawn(
                 self.fd, encoding='utf-8', codec_errors='replace')
@@ -182,9 +182,9 @@ class StataSession():
             self.log_fd = pexpect.fdpexpect.fdspawn(
                 self.fd, encoding='utf-8', maxread=1, codec_errors='replace')
 
-        self.log_fd.logfile = open(
-            self.config.get('cache_dir') / 'console_debug.log', 'w',
-            encoding='utf-8')
+        self.log_fd.logfile = (
+            self.config.get('cache_dir') / 'console_debug.log').open(
+                'w', encoding='utf-8')
 
         return 0
 


### PR DESCRIPTION
closes #203 

Had to:

- Fix use of `Path` with `open`. You can't do `with open(Path())` in Python 3.5. It has to be a string or do `Path().open()`.
- Pass config file name as a string to ConfigParser
- Fix graph regular expression to not use `(?i:`, which was unavailable in 3.5.