### PR TITLE
Fix matrix and scalar autocompletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix `scatter` in graph regex. Only `sc` and `scatter` produce plots when not
   preceded by `twoway`. #205
+- Give matrix and scalar autocompletions when using shortened command names.
+  #206
 
 ## [1.5.9] - 2018-10-16
 

--- a/stata_kernel/completions.py
+++ b/stata_kernel/completions.py
@@ -139,9 +139,9 @@ class CompletionsManager(object):
             if linecontext:
                 context = linecontext.groupdict()['context']
                 equals = (code.find('=') > 0)
-                if context.strip() == 'scalar':
+                if re.match(r'^sca(lar|la|l)?$', context.strip()):
                     env_add = 7 if equals else 4
-                elif context.strip() == 'matrix':
+                elif re.match(r'^mat(rix|ri|r)?$', context.strip()):
                     env_add = 8 if equals else 6
 
             # Constructs of the form scalar(x<tab> will be filled only


### PR DESCRIPTION
Give matrix and scalar autocompletions when using shortened command names

closes #206