### PR TITLE
Refactor `%browse` to use the same code as `%head`

### DIFF
--- a/stata_kernel/ado/_StataKernelHead.ado
+++ b/stata_kernel/ado/_StataKernelHead.ado
@@ -1,6 +1,6 @@
 capture program drop _StataKernelHead
 program _StataKernelHead
-    syntax [anything] [if] using, [*]
+    syntax [anything] [if] using, [N_default(int 10) *]
     set more off
     set trace off
     if ( !`=_N > 0' ) error 2000
@@ -15,7 +15,7 @@ program _StataKernelHead
         if ( _rc ) error 198
         local n = `n1'
     }
-    else local n = 10
+    else local n = `N_default'
 
     * Number of rows must be positive
     if ( `n' <= 0 ) {

--- a/stata_kernel/ado/_StataKernelHead.ado
+++ b/stata_kernel/ado/_StataKernelHead.ado
@@ -43,7 +43,7 @@ program _StataKernelHead
         }
     }
     else {
-        local ifin in 1 / `n'
+        local ifin in 1 / `=min(`n', _N)'
     }
 
     qui export delimited `index' `varlist' `using' `ifin', replace `options'

--- a/stata_kernel/ado/_StataKernelHead.ado
+++ b/stata_kernel/ado/_StataKernelHead.ado
@@ -1,6 +1,6 @@
 capture program drop _StataKernelHead
 program _StataKernelHead
-    syntax [anything] [if] using, [N_default(int 10) *]
+    syntax [anything] [if] using, [n_default(int 10) *]
     set more off
     set trace off
     if ( !`=_N > 0' ) error 2000
@@ -15,7 +15,7 @@ program _StataKernelHead
         if ( _rc ) error 198
         local n = `n1'
     }
-    else local n = `N_default'
+    else local n = `n_default'
 
     * Number of rows must be positive
     if ( `n' <= 0 ) {

--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -265,7 +265,7 @@ class StataMagics():
         hasif = re.search(r"\bif\b", code) is not None
         using = kernel.conf.get('cache_dir') / 'data_head.csv'
         cmd = '_StataKernelHead ' + code.strip() + ' using ' + str(using)
-        cmd += ' , N_default({})'.format(N)
+        cmd += ' , n_default({})'.format(N)
         cm = CodeManager(cmd)
         text_to_run, md5, text_to_exclude = cm.get_text(kernel.conf)
         rc, res = kernel.stata.do(text_to_run, md5, text_to_exclude=text_to_exclude, display=False)

--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -246,7 +246,8 @@ class StataMagics():
             try:
                 self.parse.browse.error(res)
             except:
-                return ''
+                pass
+        return ''
 
     def magic_head(self, code, kernel, N=None):
         self.status = -1
@@ -259,7 +260,8 @@ class StataMagics():
             try:
                 self.parse.head.error(res)
             except:
-                return ''
+                pass
+        return ''
 
     def show_data_head(self, code, kernel, N=10):
         hasif = re.search(r"\bif\b", code) is not None

--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -44,6 +44,12 @@ class MagicParsers():
             required=False)
 
         self.browse = StataParser(prog='%browse', kernel=kernel)
+        self.browse = StataParser(
+            prog='%browse', kernel=kernel,
+            usage='%(prog)s [-h] [N] [varlist] [if]',
+            description="Display the first N rows of the dataset in memory.")
+        self.browse.add_argument(
+            'code', nargs='*', type=str, help=SUPPRESS)
 
         self.time = StataParser(prog='%time', kernel=kernel)
         self.time.add_argument(
@@ -230,45 +236,41 @@ class StataMagics():
                     print_kernel(fmt.format(t, l), kernel)
 
     def magic_browse(self, code, kernel):
-        cmd = """\
-            if _N <= 200 {{
-                export delim `"{0}/data.csv"', replace datafmt
-            }}
-            else {{
-                export delim `"{0}/data.csv"' in 1/200, replace datafmt
-
-            }}
-            """.format(kernel.conf.get('cache_dir'))
-        cm = CodeManager(cmd)
-        text_to_run, md5, text_to_exclude = cm.get_text(kernel.conf)
-        rc, res = kernel.stata.do(
-            text_to_run, md5, text_to_exclude=text_to_exclude, display=False)
-        df = pd.read_csv(kernel.conf.get('cache_dir') / 'data.csv')
-        df.index += 1
-        html = df.to_html(na_rep='.', notebook=True)
-        content = {'data': {'text/html': html}, 'metadata': {}}
-        kernel.send_response(kernel.iopub_socket, 'display_data', content)
         self.status = -1
-        return ''
+        try:
+            self.parse.browse.parse_args(code.split(' '))
+        except:
+            return ''
+        res = self.show_data_head(code, kernel, N=200)
+        if res:
+            try:
+                self.parse.browse.error(res)
+            except:
+                return ''
 
-    def magic_head(self, code, kernel):
+    def magic_head(self, code, kernel, N=None):
         self.status = -1
         try:
             self.parse.head.parse_args(code.split(' '))
         except:
             return ''
-
-        hasif = re.search(r"\bif\b", code) is not None
-        using = kernel.conf.get('cache_dir') / 'data_head.csv'
-        cmd = '_StataKernelHead ' + code.strip() + ' using ' + str(using)
-        cm = CodeManager(cmd)
-        text_to_run, md5, text_to_exclude = cm.get_text(kernel.conf)
-        rc, res = kernel.stata.do(text_to_run, md5, text_to_exclude=text_to_exclude, display=False)
-        if rc:
+        res = self.show_data_head(code, kernel, N=10)
+        if res:
             try:
                 self.parse.head.error(res)
             except:
                 return ''
+
+    def show_data_head(self, code, kernel, N=10):
+        hasif = re.search(r"\bif\b", code) is not None
+        using = kernel.conf.get('cache_dir') / 'data_head.csv'
+        cmd = '_StataKernelHead ' + code.strip() + ' using ' + str(using)
+        cmd += ' , N_default({})'.format(N)
+        cm = CodeManager(cmd)
+        text_to_run, md5, text_to_exclude = cm.get_text(kernel.conf)
+        rc, res = kernel.stata.do(text_to_run, md5, text_to_exclude=text_to_exclude, display=False)
+        if rc:
+            return res
         else:
             if hasif:
                 df = pd.read_csv(using, index_col = 0)


### PR DESCRIPTION
Supersedes https://github.com/kylebarron/stata_kernel/pull/89.

Fixes #215
