### PR TITLE
Fixed ctrl-c behavior.

### DIFF
--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -214,6 +214,9 @@ class StataSession():
             rc, res = self.expect(text=text, child=child, md5=md5, **kwargs)
         except KeyboardInterrupt:
             self.send_break(child=child, md5="`{}'".format(md5))
+            # expect twice because the md5 was sent to the log twice
+            self.expect(text=text, child=child, md5=md5, **kwargs)
+            self.expect(text=text, child=child, md5=md5, **kwargs)
             rc, res = 1, ''
 
         return rc, res

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -215,6 +215,7 @@ class StataSession():
         except KeyboardInterrupt:
             self.send_break(child=child, md5="`{}'".format(md5))
             # expect twice because the md5 was sent to the log twice
+            kwargs.update({'display': False})
             self.expect(text=text, child=child, md5=md5, **kwargs)
             self.expect(text=text, child=child, md5=md5, **kwargs)
             rc, res = 1, ''


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Type `sleep 10000` followed by `<C-c>` and the following error will appear:

```
[IPKernelApp] ERROR | Exception in message handler:
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/ipykernel/kernelbase.py", line 259, in dispatch_shell
    yield gen.maybe_future(handler(stream, idents, msg))
  File "/usr/lib/python3.7/site-packages/tornado/gen.py", line 1133, in run
    value = future.result()
  File "/usr/lib/python3.7/site-packages/tornado/gen.py", line 326, in wrapper
    yielded = next(result)
  File "/usr/lib/python3.7/site-packages/ipykernel/kernelbase.py", line 513, in execute_request
    user_expressions, allow_stdin,
  File "/home/mauricio/Documents/projects/dev/code/stata_kernel/stata_kernel/kernel.py", line 114, in do_execute
    self.post_do_hook()
  File "/home/mauricio/Documents/projects/dev/code/stata_kernel/stata_kernel/kernel.py", line 140, in post_do_hook
    self.stata.linesize = int(self.quickdo("di `c(linesize)'"))
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

The log shows this is for two reasons: The md5 hashes sent to break the code were not properly cleared _and_ the rc code is parsed as 1, causing `quickdo` to return `None`.

```
$ tail ~/.stata_kernel_cache/console_debug.log -n10
--Break--
r(1);

. `ae7d24c7dc748bb5663e57339f8118a1'
. `ae7d24c7dc748bb5663e57339f8118a1'
. di `c(linesize)'
255

. `83b14c3154752dfbf1b0322b89ffcf55'
. %                                   
```

The fix is to clear the rc code and md5 hashes. A simple two-line fix.
