### PR TITLE
Completions on boundaries, e.g. gen a = (x<tab>

### DIFF
--- a/stata_kernel/completions.py
+++ b/stata_kernel/completions.py
@@ -152,7 +152,9 @@ class CompletionsManager():
         # Detect space-delimited word.
         env = 0
         env_add = 0
-        pos = max(code.rfind(' '), code.rfind('"'))
+        search = re.search(r"\b\w+\Z", code, flags=re.MULTILINE)
+        searchpos = -1 if search is None else search.start() - 1
+        pos = max(code.rfind(' '), code.rfind('"'), searchpos)
         rcomp = ''
         if pos >= 0:
             pos += 1


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Completions now work on word boundaries, not just spaces; e.g. `gen a = (x<tab>` will now suggest variables and paths starting with`x`.