### PR TITLE
Fixed %tail magic

### DIFF
--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -311,6 +311,7 @@ class StataMagics():
                 df = pd.read_csv(using, index_col = 0)
                 df.index.name = None
             else:
+                res = res.rstrip()
                 lastn = res.rfind('\n')
                 nobs = int(res[lastn:].strip())
                 res = res[:lastn]


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Simple one-liner. `%tail` magic currently fails because it doesn't retrieve the number of observations correctly (it assumes no trailing spaces, so this simply right-trims the results from the console).