### PR TITLE
Fixes 240; automation opens a log file explicitly

### DIFF
--- a/stata_kernel/ado/_StataKernelCompletions.ado
+++ b/stata_kernel/ado/_StataKernelCompletions.ado
@@ -16,7 +16,10 @@ program _StataKernelCompletions
     qui log query _all
     if ( `"`r(numlogs)'"' != "" ) {
         forvalues l = 1 / `r(numlogs)' {
-            disp r(filename`l')
+            * Skip stata automation log
+            if ( `"`r(name`l')'"' != "stata_kernel_log" ) {
+                disp r(filename`l')
+            }
         }
     }
     disp "%scalars%"

--- a/stata_kernel/ado/_StataKernelLog.ado
+++ b/stata_kernel/ado/_StataKernelLog.ado
@@ -11,7 +11,10 @@ program _StataKernelLog
     }
     if ( `"`0'"' == "off" ) {
         qui foreach logname of local lognames {
-            if ( `"`logname'"' == "<unnamed>" ) {
+            if ( `"`logname'"' == "stata_kernel_log" ) {
+                * Skip stata automation log
+            }
+            else if ( `"`logname'"' == "<unnamed>" ) {
                 log off
             }
             else {
@@ -21,7 +24,10 @@ program _StataKernelLog
     }
     else if ( `"`0'"' == "on" ) {
         qui foreach logname of local lognames {
-            if ( `"`logname'"' == "<unnamed>" ) {
+            if ( `"`logname'"' == "stata_kernel_log" ) {
+                * Skip stata automation log
+            }
+            else if ( `"`logname'"' == "<unnamed>" ) {
                 log on
             }
             else {


### PR DESCRIPTION
Skip log called `stata_kernel_log` from log cleaning or log files list.

- [X] closes #240
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
