### PR TITLE
Fix URL encoding of %help. Fixes #272

### DIFF
--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -599,12 +599,18 @@ class StataMagics():
             # Set root for links to https://ww.stata.com
             for a in soup.find_all('a', href=True):
                 href = a.get('href')
-                relative = href.find(cmd + '#')
-                if relative >= 0:
+                match = re.search(r'{}(.*?)#'.format(cmd), href)
+                if match:
                     hrelative = href.find('#')
                     a['href'] = href[hrelative:]
                 elif not href.startswith('http'):
-                    a['href'] = urllib.parse.urljoin(self.html_base, href)
+                    link = a['href']
+                    match = re.search(r'/help.cgi\?(.+)$', link)
+                    # URL encode bad characters like %
+                    if match:
+                        link = '/help.cgi?'
+                        link += urllib.parse.quote_plus(match.group(1))
+                    a['href'] = urllib.parse.urljoin(self.html_base, link)
                     a['target'] = '_blank'
 
             # Remove header 'Stata 15 help for ...'
@@ -664,10 +670,10 @@ class StataMagics():
     def magic_status(self, code, kernel):
         self.status = -1
         delim = ';' if kernel.sc_delimit_mode else 'cr'
-        env = 'mata' if kernel.stata.mata_mode else 'stata'
+        env = 'Mata' if kernel.stata.mata_mode else 'Stata'
         info = (
             kernel.implementation, kernel.implementation_version,
-            kernel.language, kernel.language_version)
+            kernel.language.title(), kernel.language_version)
         print_kernel('{0} {1} for {2} {3}'.format(*info), kernel)
         print_kernel('\tDelimiter:   {}'.format(delim), kernel)
         print_kernel('\tEnvironment: {}'.format(env), kernel)


### PR DESCRIPTION
- [x] closes #272
- [x] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This URL encodes the part of the string after `/help.cgi?`.