### PR TITLE
Revert "Remove consecutive whitespace from commands sent to Stata"

### DIFF
--- a/stata_kernel/stata_lexer.py
+++ b/stata_kernel/stata_lexer.py
@@ -1,6 +1,6 @@
 import re
 from pygments.lexer import RegexLexer, include
-from pygments.token import Comment, Text, Token, String
+from pygments.token import Comment, Text, Token
 
 
 # yapf: disable
@@ -36,8 +36,8 @@ class StataLexer(RegexLexer):
     flags = re.MULTILINE | re.DOTALL
     tokens = {
         'root': [
-            (r'`"', String, 'string-compound'),
-            (r'(?<!`)"', String, 'string-regular'),
+            (r'`"', Text, 'string-compound'),
+            (r'(?<!`)"', Text, 'string-regular'),
             (r'^[^\r\n\S]*m(ata)?[^\r\n\S]*$', Token.Mata.Open, 'mata'),
             (r'^[^\r\n\S]*m(ata)?[^\r\n\S]*:[^\r\n\S]*$', Token.Mata.OpenError, 'mata'),
             (r'\{', Token.TextBlock, 'block'),
@@ -89,9 +89,9 @@ class StataLexer(RegexLexer):
         ],
         'strings': [
             # `"compound string"'
-            (r'`"', String, 'string-compound'),
+            (r'`"', Text, 'string-compound'),
             # "string"
-            (r'(?<!`)"', String, 'string-regular'),
+            (r'(?<!`)"', Text, 'string-regular'),
         ],
         'strings-inside-blocks': [
             # `"compound string"'
@@ -100,13 +100,13 @@ class StataLexer(RegexLexer):
             (r'(?<!`)"', Token.TextBlock, 'string-regular-inside-blocks'),
         ],
         'string-compound': [
-            (r'`"', String, '#push'),
-            (r'"\'', String, '#pop'),
-            (r'.', String)
+            (r'`"', Text, '#push'),
+            (r'"\'', Text, '#pop'),
+            (r'.', Text)
         ],
         'string-regular': [
-            (r'(")(?!\')|(?=\n)', String, '#pop'),
-            (r'.', String)
+            (r'(")(?!\')|(?=\n)', Text, '#pop'),
+            (r'.', Text)
         ],
         'string-compound-inside-blocks': [
             (r'`"', Token.TextBlock, '#push'),

--- a/tests/test_mata_lexer.py
+++ b/tests/test_mata_lexer.py
@@ -1,5 +1,5 @@
 import pytest
-from pygments.token import Token, String
+from pygments.token import Token
 from stata_kernel.code_manager import CodeManager
 
 
@@ -752,15 +752,15 @@ class TestSemicolonDelimitCommentsMata(object):
             (Token.Mata.Open, ' mata'),
             (Token.Text, '\n'),
             (Token.Text, ' '),
-            (String, '"'),
-            (String, ' '),
-            (String, 'a'),
-            (String, ' '),
-            (String, '2'),
-            (String, ' '),
-            (String, 'b'),
-            (String, ' '),
-            (String, '"'),
+            (Token.Text, '"'),
+            (Token.Text, ' '),
+            (Token.Text, 'a'),
+            (Token.Text, ' '),
+            (Token.Text, '2'),
+            (Token.Text, ' '),
+            (Token.Text, 'b'),
+            (Token.Text, ' '),
+            (Token.Text, '"'),
             (Token.Text, ' '),
             (Token.Mata.Close, '\n end'),
             (Token.Text, '\n')]

--- a/tests/test_stata_lexer.py
+++ b/tests/test_stata_lexer.py
@@ -1,5 +1,5 @@
 import pytest
-from pygments.token import Token, Text, String
+from pygments.token import Token
 from stata_kernel.code_manager import CodeManager
 
 
@@ -506,74 +506,19 @@ class TestBlocks(object):
             (Token.Text, 'i'),
             (Token.Text, 'f'),
             (Token.Text, ' '),
-            (String, '"'),
-            (String, '0'),
-            (String, '"'),
+            (Token.Text, '"'),
+            (Token.Text, '0'),
+            (Token.Text, '"'),
             (Token.Text, ' '),
             (Token.Text, '='),
             (Token.Text, '='),
             (Token.Text, ' '),
-            (String, '"'),
-            (String, '1'),
-            (String, '"'),
+            (Token.Text, '"'),
+            (Token.Text, '1'),
+            (Token.Text, '"'),
             (Token.Text, ' '),
             (Token.TextBlock, '{'),
             (Token.TextBlock, '\n')]
-        assert tokens == expected
-
-class TestRemovingConsecutiveWhitespace():
-    def test_whitespace(self):
-        code = 'a   b'
-        tokens = CodeManager(code).tokens_final
-        expected = [
-            (Text, 'a'),
-            (Text, ' '),
-            (Text, 'b'),
-            (Text, '\n')]
-        assert tokens == expected
-
-    def test_whitespace2(self):
-        code = 'a ///\n   b'
-        tokens = CodeManager(code).tokens_final
-        expected = [
-            (Text, 'a'),
-            (Text, ' '),
-            (Text, 'b'),
-            (Text, '\n')]
-        assert tokens == expected
-
-    def test_whitespace3(self):
-        code = 'a "   "   b'
-        tokens = CodeManager(code).tokens_final
-        expected = [
-            (Text, 'a'),
-            (Text, ' '),
-            (String, '"'),
-            (String, ' '),
-            (String, ' '),
-            (String, ' '),
-            (String, '"'),
-            (Text, ' '),
-            (Text, 'b'),
-            (Text, '\n')]
-        assert tokens == expected
-
-    def test_whitespace4(self):
-        code = 'a,     a("   ")'
-        tokens = CodeManager(code).tokens_final
-        expected = [
-            (Text, 'a'),
-            (Text, ','),
-            (Text, ' '),
-            (Text, 'a'),
-            (Text, '('),
-            (String, '"'),
-            (String, ' '),
-            (String, ' '),
-            (String, ' '),
-            (String, '"'),
-            (Text, ')'),
-            (Text, '\n')]
         assert tokens == expected
 
 class TestSemicolonDelimitComments(object):


### PR DESCRIPTION
Reverts kylebarron/stata_kernel#285

Now that I've set `maxread` [appropriately](https://github.com/kylebarron/stata_kernel/commit/de64e9fa39b2ba00aa7721c073b774f511cf7b3a) I don't think this is necessary, and it's more likely to create bugs that are hard to find/fix.