### PR TITLE
Fix fdpexpect with long windows commands

### DIFF
--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -448,12 +448,19 @@ class StataSession():
         # Remove the characters that were matched. If there's still text left,
         # it's on the next line.
         code_lines[0] = code_lines[0][len(res):]
+        res = ''
         while code_lines[0]:
-            child.expect(r'\r?\n', timeout=5)
-            res = child.before
-            assert child.before.startswith('> ')
+            try:
+                child.expect(r'\r?\n', timeout=5)
+                res += child.before
+            except pexpect.EOF:
+                res += child.before
+                sleep(0.05)
+                continue
+            assert res.startswith('> ')
             res = res[2:]
             code_lines[0] = code_lines[0][len(res):]
+            res = ''
 
         return code_lines[1:], None
 


### PR DESCRIPTION
In the main expect clause in the `expect()` function, we catch 
`pexpect.EOF` and then sleep a little and try again. 

Here we do the same thing but inside the clause to remove long 
user-entered commands. It's important to still add the caught output 
when you hit `pexpect.EOF`. So `res` after passing the `try` 
successfully should be the same as if it never hit `pexpect.EOF`

- [x] closes #284
