### PR TITLE
Global config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ python:
     - "3.6"
 install:
     - pip install -r requirements.txt -r requirements_dev.txt
+    - python -m stata_kernel.install
 script:
     - python -m pytest tests/test_mata_lexer.py tests/test_stata_lexer.py
     - python setup.py install
-    - python -m stata_kernel.install
 # deploy:
 #     provider: pages
 #     skip-cleanup: true

--- a/stata_kernel/code_manager.py
+++ b/stata_kernel/code_manager.py
@@ -131,14 +131,16 @@ class CodeManager():
             return tokens
 
         # Replace newlines in `;`-delimited blocks with spaces
-        tokens = [('Space instead of newline', ' ')
-                  if (str(x[0]) == 'Token.TextInSemicolonBlock')
-                  and x[1] == '\n' else x for x in tokens[:-1]]
+        tokens = [
+            ('Space instead of newline', ' ') if
+            (str(x[0]) == 'Token.TextInSemicolonBlock') and x[1] == '\n' else x
+            for x in tokens[:-1]]
 
         # Change the ; delimiters to \n
-        tokens = [('Newline delimiter', '\n')
-                  if (str(x[0]) == 'Token.SemicolonDelimiter') and x[1] == ';'
-                  else x for x in tokens]
+        tokens = [
+            ('Newline delimiter', '\n') if
+            (str(x[0]) == 'Token.SemicolonDelimiter') and x[1] == ';' else x
+            for x in tokens]
         return tokens
 
     def tokenize_second_pass(self, code):

--- a/stata_kernel/code_manager.py
+++ b/stata_kernel/code_manager.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 
 from .stata_lexer import StataLexer
 from .stata_lexer import CommentAndDelimitLexer
+from .config import config
 
 base_graph_keywords = [
     r'gr(a|ap|aph)?' + r'(?!\s+' + r'(save|replay|print|export|dir|set|' +
@@ -210,7 +211,7 @@ class CodeManager():
 
         return True
 
-    def get_text(self, config, stata=None):
+    def get_text(self, stata=None):
         """Get valid, executable text
 
         For any text longer than one line, I save the text to a do file and send
@@ -223,7 +224,7 @@ class CodeManager():
         code I sent it.
 
         Args:
-            config (.config.Config): Configuration instance
+            stata: instance of Stata session
 
         Returns:
             (str, str, str):

--- a/stata_kernel/completions.py
+++ b/stata_kernel/completions.py
@@ -4,14 +4,14 @@ import platform
 
 from .code_manager import CodeManager
 from .pygments._mata_builtins import mata_builtins
+from .config import config
 
 
 # NOTE: Add command completion (e.g. r<tab>; mata: st_<tab>)
 # NOTE: Add extended_fcn completions, `:<tab>
 # NOTE: Add sub-command completions for scalars and matrices?
 class CompletionsManager():
-    def __init__(self, kernel, config):
-        self.config = config
+    def __init__(self, kernel):
         self.kernel = kernel
 
         # Path completion
@@ -96,12 +96,12 @@ class CompletionsManager():
 
         self.suggestions = self.get_suggestions(kernel)
         self.suggestions['magics'] = kernel.magics.available_magics
-        self.suggestions['magics_set'] = kernel.conf.all_settings
+        self.suggestions['magics_set'] = config.all_settings
 
     def refresh(self, kernel):
         self.suggestions = self.get_suggestions(kernel)
         self.suggestions['magics'] = kernel.magics.available_magics
-        self.suggestions['magics_set'] = kernel.conf.all_settings
+        self.suggestions['magics_set'] = config.all_settings
         self.globals = self.get_globals(kernel)
 
     def get_env(self, code, rdelimit, sc_delimit_mode, mata_mode):
@@ -291,7 +291,7 @@ class CompletionsManager():
 
                 pos += posextra
 
-        closing_symbol = self.config.get('autocomplete_closing_symbol', 'False')
+        closing_symbol = config.get('autocomplete_closing_symbol', 'False')
         closing_symbol = closing_symbol.lower() == 'true'
         if not closing_symbol:
             rcomp = ''
@@ -482,7 +482,7 @@ class CompletionsManager():
     def quickdo(self, code, kernel):
         code = kernel.stata._mata_escape(code)
         cm = CodeManager(code)
-        text_to_run, md5, text_to_exclude = cm.get_text(kernel.conf)
+        text_to_run, md5, text_to_exclude = cm.get_text()
         rc, res = kernel.stata.do(
             text_to_run, md5, text_to_exclude=text_to_exclude, display=False)
         return res

--- a/stata_kernel/completions.py
+++ b/stata_kernel/completions.py
@@ -87,12 +87,12 @@ class CompletionsManager():
                     r"\([^\)\s]*?\Z", **kwargs).search,
             'line':
                 re.compile(
-                    r"^\s*({0}\s+)*(?P<context>\S+)".format(pre), **kwargs)
-                .search,
+                    r"^\s*({0}\s+)*(?P<context>\S+)".format(pre),
+                    **kwargs).search,
             'delimit_line':
                 re.compile(
-                    r"\A\s*({0}\s+)*(?P<context>\S+)".format(pre), **kwargs)
-                .search}
+                    r"\A\s*({0}\s+)*(?P<context>\S+)".format(pre),
+                    **kwargs).search}
 
         self.suggestions = self.get_suggestions(kernel)
         self.suggestions['magics'] = kernel.magics.available_magics
@@ -315,8 +315,8 @@ class CompletionsManager():
             return [
                 var for var in self.suggestions['programs']
                 if var.startswith(starts)] + [
-                var for var in self.suggestions['varlist']
-                if var.startswith(starts)] + paths
+                    var for var in self.suggestions['varlist']
+                    if var.startswith(starts)] + paths
         elif env == 1:
             return [
                 var + rcomp
@@ -440,7 +440,8 @@ class CompletionsManager():
         if match:
             suggestions = match.groupdict()
             suggestions['mata'] = self._parse_mata_desc(suggestions['mata'])
-            suggestions['programs'] = self._parse_programs_desc(suggestions['programs'])
+            suggestions['programs'] = self._parse_programs_desc(
+                suggestions['programs'])
             for k, v in suggestions.items():
                 if k in ['mata', 'programs']:
                     continue
@@ -514,7 +515,9 @@ class CompletionsManager():
             items = items[:-1]
 
         # Remove stata-kernel ado files
-        files = ['_StataKernelCompletions', '_StataKernelHead', '_StataKernelLog', '_StataKernelTail']
+        files = [
+            '_StataKernelCompletions', '_StataKernelHead', '_StataKernelLog',
+            '_StataKernelTail']
         items = [x for x in items if x not in files]
 
         # Remove if period in name

--- a/stata_kernel/config.py
+++ b/stata_kernel/config.py
@@ -122,3 +122,5 @@ class Config():
             self.config.remove_option(option=key, section='stata_kernel')
             with self.config_path.open('w') as f:
                 self.config.write(f)
+
+config = Config()

--- a/stata_kernel/config.py
+++ b/stata_kernel/config.py
@@ -123,4 +123,5 @@ class Config():
             with self.config_path.open('w') as f:
                 self.config.write(f)
 
+
 config = Config()

--- a/stata_kernel/install.py
+++ b/stata_kernel/install.py
@@ -24,6 +24,7 @@ if sys.version_info[0] < 3:
 if sys.version_info[1] < 5:
     raise ImportError('Python < 3.5 is unsupported.')
 
+
 def install_my_kernel_spec(user=True, prefix=None):
     with TemporaryDirectory() as td:
         os.chmod(td, 0o755)  # Starts off as 700, not user readable

--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -3,12 +3,13 @@ import re
 import urllib
 import pandas as pd
 from textwrap import dedent
-from argparse import ArgumentParser, SUPPRESS
-
 from bs4 import BeautifulSoup as bs
-from .utils import check_stata_kernel_updated_version
-from .code_manager import CodeManager
+from argparse import ArgumentParser, SUPPRESS
 from pkg_resources import resource_filename
+
+from .config import config
+from .code_manager import CodeManager
+from .utils import check_stata_kernel_updated_version
 
 
 class StataParser(ArgumentParser):
@@ -290,11 +291,11 @@ class StataMagics():
 
     def show_data_head(self, code, kernel, N=10):
         hasif = re.search(r"\bif\b", code) is not None
-        using = kernel.conf.get('cache_dir') / 'data_head.csv'
+        using = config.get('cache_dir') / 'data_head.csv'
         cmd = '_StataKernelHead ' + code.strip() + ' using ' + str(using)
         cmd += ' , n_default({})'.format(N)
         cm = CodeManager(cmd)
-        text_to_run, md5, text_to_exclude = cm.get_text(kernel.conf)
+        text_to_run, md5, text_to_exclude = cm.get_text()
         rc, res = kernel.stata.do(
             text_to_run, md5, text_to_exclude=text_to_exclude, display=False)
         if rc:
@@ -325,10 +326,10 @@ class StataMagics():
             return ''
 
         hasif = re.search(r"\bif\b", code) is not None
-        using = kernel.conf.get('cache_dir') / 'data_tail.csv'
+        using = config.get('cache_dir') / 'data_tail.csv'
         cmd = '_StataKernelTail ' + code.strip() + ' using ' + str(using)
         cm = CodeManager(cmd)
-        text_to_run, md5, text_to_exclude = cm.get_text(kernel.conf)
+        text_to_run, md5, text_to_exclude = cm.get_text()
         rc, res = kernel.stata.do(
             text_to_run, md5, text_to_exclude=text_to_exclude, display=False)
         if rc:
@@ -388,7 +389,7 @@ class StataMagics():
             return code
 
         cm = CodeManager(kernel.stata._mata_escape("macro dir"))
-        text_to_run, md5, text_to_exclude = cm.get_text(kernel.conf)
+        text_to_run, md5, text_to_exclude = cm.get_text()
         rc, res = kernel.stata.do(
             text_to_run, md5, text_to_exclude=text_to_exclude, display=False)
         if rc:
@@ -463,7 +464,7 @@ class StataMagics():
 
     def magic_html(self, code, kernel):
         cm = CodeManager(code)
-        text_to_run, md5, text_to_exclude = cm.get_text(kernel.conf)
+        text_to_run, md5, text_to_exclude = cm.get_text()
         rc, res = kernel.stata.do(
             text_to_run, md5, text_to_exclude=text_to_exclude, display=False)
         if rc:
@@ -480,7 +481,7 @@ class StataMagics():
 
     def magic_latex(self, code, kernel):
         cm = CodeManager(code)
-        text_to_run, md5, text_to_exclude = cm.get_text(kernel.conf)
+        text_to_run, md5, text_to_exclude = cm.get_text()
         rc, res = kernel.stata.do(
             text_to_run, md5, text_to_exclude=text_to_exclude, display=False)
         if rc:
@@ -510,12 +511,12 @@ class StataMagics():
                     self.parse.set.error(msg)
 
                 # reset graph settings
-                kernel.conf.set('graph_format', 'svg', permanent=perm)
-                kernel.conf.set('graph_scale', '1', permanent=perm)
-                kernel.conf._remove_unsafe('graph_width', permanent=perm)
-                kernel.conf._remove_unsafe('graph_height', permanent=perm)
+                config.set('graph_format', 'svg', permanent=perm)
+                config.set('graph_scale', '1', permanent=perm)
+                config._remove_unsafe('graph_width', permanent=perm)
+                config._remove_unsafe('graph_height', permanent=perm)
             else:
-                kernel.conf.set(key, value, permanent=perm)
+                config.set(key, value, permanent=perm)
 
         except:
             pass

--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -51,14 +51,14 @@ class MagicParsers():
             description="Display the first N rows of the dataset in memory.")
         self.browse.add_argument('code', nargs='*', type=str, help=SUPPRESS)
 
-        self.html = StataParser(prog='%html', kernel=kernel,
-            usage='%(prog)s [-h] code',
+        self.html = StataParser(
+            prog='%html', kernel=kernel, usage='%(prog)s [-h] code',
             description="Display output of code as HTML.")
         self.html.add_argument(
             'code', nargs='*', type=str, metavar='CODE', help="Code to run")
 
-        self.latex = StataParser(prog='%latex', kernel=kernel,
-            usage='%(prog)s [-h] code',
+        self.latex = StataParser(
+            prog='%latex', kernel=kernel, usage='%(prog)s [-h] code',
             description="Display output of code as LaTeX.")
         self.latex.add_argument(
             'code', nargs='*', type=str, metavar='CODE', help="Code to run")
@@ -158,13 +158,15 @@ class MagicParsers():
             help="Restore default settings.", required=False)
 
         self.show_gui = StataParser(
-            prog='%show_gui', kernel=kernel,
-            description="Show Stata GUI. Only works on Windows (and Mac if using automation execution mode)")
+            prog='%show_gui', kernel=kernel, description=
+            "Show Stata GUI. Only works on Windows (and Mac if using automation execution mode)"
+        )
         self.show_gui.add_argument('code', nargs='*', type=str, help=SUPPRESS)
 
         self.hide_gui = StataParser(
-            prog='%hide_gui', kernel=kernel,
-            description="Hide Stata GUI. Only works on Windows (and Mac if using automation execution mode)")
+            prog='%hide_gui', kernel=kernel, description=
+            "Hide Stata GUI. Only works on Windows (and Mac if using automation execution mode)"
+        )
         self.hide_gui.add_argument('code', nargs='*', type=str, help=SUPPRESS)
 
 
@@ -191,8 +193,8 @@ class StataMagics():
         'show_gui',
         'status',
         'tail']
-        # 'time',
-        # 'timeit'
+    # 'time',
+    # 'timeit'
 
     csshelp_default = resource_filename(
         'stata_kernel', 'css/_StataKernelHelpDefault.css')
@@ -472,8 +474,10 @@ class StataMagics():
         else:
             content = {
                 'data': {
-                    'text/plain': 'This front-end or document format cannot display HTML',
-                    'text/html': res},
+                    'text/plain':
+                        'This front-end or document format cannot display HTML',
+                    'text/html':
+                        res},
                 'metadata': {}}
             kernel.send_response(kernel.iopub_socket, 'display_data', content)
 
@@ -489,8 +493,10 @@ class StataMagics():
         else:
             content = {
                 'data': {
-                    'text/plain': 'This front-end or document format cannot display LaTeX',
-                    'text/latex': res},
+                    'text/plain':
+                        'This front-end or document format cannot display LaTeX',
+                    'text/latex':
+                        res},
                 'metadata': {}}
             kernel.send_response(kernel.iopub_socket, 'display_data', content)
 

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -176,8 +176,7 @@ class StataSession():
         gone away.
         """
         self.child = pexpect.spawn(
-            config.get('stata_path'), encoding='utf-8',
-            codec_errors='replace')
+            config.get('stata_path'), encoding='utf-8', codec_errors='replace')
         self.child.setwinsize(100, 255)
         self.child.delaybeforesend = None
         self.child.logfile = (
@@ -215,8 +214,7 @@ class StataSession():
         log_counter = 0
         rc = 1
         while (rc) and (log_counter < 15):
-            log_path = config.get('cache_dir') / 'log{}.log'.format(
-                log_counter)
+            log_path = config.get('cache_dir') / 'log{}.log'.format(log_counter)
             cmd = 'log using `"{}"\', replace text name(stata_kernel_log)'.format(
                 log_path)
             rc = self.automate('DoCommand', cmd)

--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -10,7 +10,9 @@ from time import sleep
 from pathlib import Path
 from textwrap import dedent
 from pkg_resources import resource_filename
+
 from .utils import check_stata_kernel_updated_version
+from .config import config
 
 if platform.system() == 'Windows':
     import win32com.client
@@ -35,14 +37,13 @@ ansi_escape = re.compile(ansi_regex, flags=re.IGNORECASE)
 
 
 class StataSession():
-    def __init__(self, kernel, config):
+    def __init__(self, kernel):
         """Initialize Session
         Args:
             kernel (ipykernel.kernelbase): Running instance of kernel
             config (ConfigParser): config class
         """
 
-        self.config = config
         self.kernel = kernel
         self.banner = 'stata_kernel {}\n'.format(kernel.implementation_version)
 
@@ -85,13 +86,13 @@ class StataSession():
         if platform.system() == 'Windows':
             self.init_windows()
         elif platform.system() == 'Darwin':
-            if self.config.get('execution_mode') == 'automation':
+            if config.get('execution_mode') == 'automation':
                 self.init_mac_automation()
             else:
                 self.init_console()
         else:
             self.init_console()
-            self.config.set('execution_mode', 'console', permanent=True)
+            config.set('execution_mode', 'console', permanent=True)
 
         # Stata
         # -----
@@ -119,7 +120,7 @@ class StataSession():
         self.stata_version = res
         isold = int(self.stata_version[:2]) < 15
         if (platform.system() == 'Windows') and isold:
-            self.config.set('graph_format', 'png', permanent=True)
+            config.set('graph_format', 'png', permanent=True)
 
     def init_windows(self):
         """Start Stata on Windows
@@ -127,7 +128,7 @@ class StataSession():
         Until version 1.8.0, I included
         ```py
         from win32api import WinExec
-        WinExec(self.config.get('stata_path'))
+        WinExec(config.get('stata_path'))
         ```
         _before_ calling `win32com.client.Dispatch`. When opening a new Stata
         session using `win32com.client.Dispatch`, graph windows from the Stata
@@ -157,7 +158,7 @@ class StataSession():
             raise com_error(dedent(msg))
 
         self.automate(cmd_name='UtilShowStata', value=1)
-        self.config.set('execution_mode', 'automation', permanent=True)
+        config.set('execution_mode', 'automation', permanent=True)
         self.start_log_aut()
 
     def init_mac_automation(self):
@@ -175,12 +176,12 @@ class StataSession():
         gone away.
         """
         self.child = pexpect.spawn(
-            self.config.get('stata_path'), encoding='utf-8',
+            config.get('stata_path'), encoding='utf-8',
             codec_errors='replace')
         self.child.setwinsize(100, 255)
         self.child.delaybeforesend = None
         self.child.logfile = (
-            self.config.get('cache_dir') / 'console_debug.log').open(
+            config.get('cache_dir') / 'console_debug.log').open(
                 'w', encoding='utf-8')
         banner = []
         try:
@@ -214,7 +215,7 @@ class StataSession():
         log_counter = 0
         rc = 1
         while (rc) and (log_counter < 15):
-            log_path = self.config.get('cache_dir') / 'log{}.log'.format(
+            log_path = config.get('cache_dir') / 'log{}.log'.format(
                 log_counter)
             cmd = 'log using `"{}"\', replace text name(stata_kernel_log)'.format(
                 log_path)
@@ -229,7 +230,7 @@ class StataSession():
         self.log_fd = pexpect.fdpexpect.fdspawn(
             self.fd, encoding='utf-8', maxread=9999999, codec_errors='replace')
         self.log_fd.logfile = (
-            self.config.get('cache_dir') / 'console_debug.log').open(
+            config.get('cache_dir') / 'console_debug.log').open(
                 'w', encoding='utf-8')
 
         return 0
@@ -249,11 +250,11 @@ class StataSession():
             display (bool): Whether to send results to front-end
         """
 
-        self.cache_dir_str = str(self.config.get('cache_dir'))
+        self.cache_dir_str = str(config.get('cache_dir'))
         if platform.system() == 'Windows':
             self.cache_dir_str = re.sub(r'\\', '/', self.cache_dir_str)
 
-        if self.config.get('execution_mode') == 'console':
+        if config.get('execution_mode') == 'console':
             self.child.sendline(text)
             child = self.child
         else:
@@ -329,9 +330,9 @@ class StataSession():
                 g_path = [child.match.group(1)]
                 g_fmt = child.match.group(2).lower()
                 if g_fmt == 'svg':
-                    pdf_dup = self.config.get('graph_svg_redundancy', 'True')
+                    pdf_dup = config.get('graph_svg_redundancy', 'True')
                 elif g_fmt == 'png':
-                    pdf_dup = self.config.get('graph_png_redundancy', 'False')
+                    pdf_dup = config.get('graph_png_redundancy', 'False')
                 pdf_dup = pdf_dup.lower() == 'true'
 
                 if pdf_dup:
@@ -479,7 +480,7 @@ class StataSession():
             child (pexpect.spawn): pexpect instance to send break to
             md5 (str): The md5 to send a second time
         """
-        if self.config.get('execution_mode') == 'console':
+        if config.get('execution_mode') == 'console':
             child.sendcontrol('c')
             child.sendcontrol('d')
             self.child.sendline(md5)
@@ -500,7 +501,7 @@ class StataSession():
                 return getattr(self.stata, cmd_name)()
             return getattr(self.stata, cmd_name)(value, **kwargs)
 
-        app_name = Path(self.config.get('stata_path')).name
+        app_name = Path(config.get('stata_path')).name
         cmd = 'tell application "{}" to {}'.format(app_name, cmd_name)
         if value is not None:
             value = str(value).replace('\n', '\\n').replace('\r', '\\r')
@@ -540,18 +541,18 @@ class StataSession():
         return stdout
 
     def shutdown(self):
-        if self.config.get('execution_mode') == 'automation':
+        if config.get('execution_mode') == 'automation':
             self.automate('DoCommandAsync', 'exit, clear')
         else:
             self.child.close(force=True)
         return
 
     def show_gui(self):
-        if self.config.get('execution_mode', '') == 'automation':
+        if config.get('execution_mode', '') == 'automation':
             self.automate(cmd_name='UtilShowStata', value=0)
 
     def hide_gui(self):
-        if self.config.get('execution_mode', '') == 'automation':
+        if config.get('execution_mode', '') == 'automation':
             self.automate(cmd_name='UtilShowStata', value=1)
 
     def _mata_refresh(self, cm):
@@ -624,7 +625,7 @@ class StataSession():
 
             self.mata_restart = True
             if re.match(r'(\r?\n)? *>(\r?\n)?', child.after):
-                if self.config.get('execution_mode') == 'console':
+                if config.get('execution_mode') == 'console':
                     child.sendcontrol('c')
                     child.sendcontrol('d')
                     child.sendline('\r\n')

--- a/stata_kernel/utils.py
+++ b/stata_kernel/utils.py
@@ -1,3 +1,4 @@
+import os
 import re
 import requests
 import platform
@@ -26,6 +27,9 @@ def check_stata_kernel_updated_version(stata_kernel_version):
 
 
 def find_path():
+    if os.getenv('CONTINUOUS_INTEGRATION'):
+        print('WARNING: Running as CI; Stata path not set correctly')
+        return 'stata'
     if platform.system() == 'Windows':
         return win_find_path()
     elif platform.system() == 'Darwin':


### PR DESCRIPTION
Use global config object instead of passing it around. I instantiate it once at the bottom of `config.py`
```py
config = Config()
```
and then import the instance instead of the class, aka
```py
from .config import config
```
instead of 
```py
from .config import Config
```

Then all files automagically get the same instance to play with.