### PR TITLE
Load graphs correctly when output wraps over multiple lines

### DIFF
--- a/stata_kernel/stata_session.py
+++ b/stata_kernel/stata_session.py
@@ -177,7 +177,6 @@ class StataSession():
         """
         self.child = pexpect.spawn(
             config.get('stata_path'), encoding='utf-8', codec_errors='replace')
-        self.child.setwinsize(100, 255)
         self.child.delaybeforesend = None
         self.child.logfile = (
             config.get('cache_dir') / 'console_debug.log').open(


### PR DESCRIPTION
- [x] closes #177
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Would probably also fix #216