### PR TITLE
Fixes #318 (spaces in log file no longer causes error)

### DIFF
--- a/stata_kernel/completions.py
+++ b/stata_kernel/completions.py
@@ -59,8 +59,11 @@ class CompletionsManager():
             r'(?P<quote>[^\)]*?")'
             r'(?P<pre>[^\)]*?)\Z', flags=re.MULTILINE + re.DOTALL).search
 
-        # Varlist-style matching; applies to all
+        # Varlist-style matching; applies to most
         self.varlist = re.compile(r"(?:\s+)(\S+)", flags=re.MULTILINE)
+
+        # file-style matching
+        self.filelist = re.compile(r"[\r\n]{1,2}", flags=re.MULTILINE)
 
         # Clean line-breaks.
         self.varclean = re.compile(
@@ -445,7 +448,11 @@ class CompletionsManager():
             for k, v in suggestions.items():
                 if k in ['mata', 'programs']:
                     continue
-                suggestions[k] = self.varlist.findall(self.varclean('', v))
+                elif k in ['logfiles']:
+                    suggestions[k] = [
+                        f for f in self.filelist.split(v.strip()) if f]
+                else:
+                    suggestions[k] = self.varlist.findall(self.varclean('', v))
 
             all_locals = """mata : invtokens(st_dir("local", "macro", "*")')"""
             res = '\r\n'.join(


### PR DESCRIPTION
stata_kernel/completions.py incorrecly parsed the logfiles that were
printed from stata_kernel/ado/_StataKernelCompletions.ado when they had
spaces. Log files were parsed using varlist parsing, which explicitly
considered spaces as a delimiter. Now only newlines are considered a
delimiter.

- [X] closes #318
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
