### PR TITLE
[DRAFT] Add support for a global configuration file.

### DIFF
--- a/docs/src/using_stata_kernel/configuration.md
+++ b/docs/src/using_stata_kernel/configuration.md
@@ -20,6 +20,11 @@ If you want these changes to be stored permanently, add `--permanently`:
 %set graph_format png --permanently
 ```
 
+!!! info "System wide configuration file for JupyterHub"
+
+    If you are installign `stata_kernel` in Jupyter Hub you must create a system
+    wide configuration file in `/etc/stata_kernel.conf` to provide default
+    values.
 
 ## General settings
 

--- a/stata_kernel/config.py
+++ b/stata_kernel/config.py
@@ -27,17 +27,17 @@ class Config():
 
     def __init__(self):
         """
-        Load config both from a potential system-wide config file, and merge
-        with a user-defined one if present.
+        Load config both from a potential system-wide config file and from a
+        user-defined one if present.
 
-        We load from the system-wide location if present first and them from the
-        user-defined location; updating entries. Thus the user-location takes
-        precedence, but either file can be missing.
+        We first load from the system-wide location if the file is present and
+        then we load the user-defined location, updating entries. Thus the
+        user-location takes precedence, but either file can be missing.
 
-        We do not keep a reference to the system-wide config as it is likely
-        non-writable; and thus setting any config option should go to the
-        user-config.
-
+        The system-wide config file was added to facilitate deployments on
+        systems like Jupyter Hub; it must be created in `/etc/stata_kernel.conf`
+        and we do not otherwise keep a reference to it because it is likely
+        non-writable. Setting any config option should go to the user-config.
         """
 
         global_config = ConfigParser()


### PR DESCRIPTION
Use '/etc/stata_kernel.conf' to pull default values from; this should
allow simpler deployment in JupyterHub environment that usually are on
linux.

This avoid to create a configuration file on a per-user basis.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

-- 

Draft, I need to try it at work where stata is installed.