### PR TITLE
Make sure pdf_dup is always defined

### DIFF
--- a/stata_kernel/code_manager.py
+++ b/stata_kernel/code_manager.py
@@ -267,9 +267,12 @@ class CodeManager():
         cache_dir = config.get('cache_dir')
         if graph_fmt == 'svg':
             pdf_dup = config.get('graph_svg_redundancy', 'True')
+            pdf_dup = pdf_dup.lower() == 'true'
         elif graph_fmt == 'png':
             pdf_dup = config.get('graph_png_redundancy', 'False')
-        pdf_dup = pdf_dup.lower() == 'true'
+            pdf_dup = pdf_dup.lower() == 'true'
+        else:
+            pdf_dup = False
 
         dim_str = " width({})".format(int(graph_width * graph_scale))
         if graph_height:


### PR DESCRIPTION
Closes #332

I think I originally planned for the `graph_format` to always be either png or svg, since in my testing Jupyter Notebook wasn't great at displaying PDFs.

The reason for `pdf_dup` is to include multiple image formats in the Jupyter Notebook, so that exporting it as a PDF through LaTeX would use the PDF image format, while usually in the browser most people would use SVG or PNG.