### PR TITLE
Support EPS graphics via user-specified program

### DIFF
--- a/stata_kernel/code_manager.py
+++ b/stata_kernel/code_manager.py
@@ -269,6 +269,8 @@ class CodeManager():
             pdf_dup = config.get('graph_svg_redundancy', 'True')
         elif graph_fmt == 'png':
             pdf_dup = config.get('graph_png_redundancy', 'False')
+        elif graph_fmt == 'eps':
+            pdf_dup = config.get('graph_eps_redundancy', 'False')
         pdf_dup = pdf_dup.lower() == 'true'
 
         dim_str = " width({})".format(int(graph_width * graph_scale))
@@ -276,6 +278,8 @@ class CodeManager():
             graph_height = int(graph_height)
             dim_str += " height({})".format(int(graph_height * graph_scale))
         if graph_fmt == 'pdf':
+            dim_str = ''
+        if graph_fmt == 'eps':
             dim_str = ''
 
         cache_dir_str = str(cache_dir)


### PR DESCRIPTION
- [X] closes #345
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

In #345 support for EPS was requested. This allows the user to specify EPS graphics if they can convert EPS to a PNG via a command line program. For example, on Linux the user can specify in `~/.stata_kernel.conf`

```
graph_format = eps
graph_epstopng_program = convert -density 300 {0} -resize '900x600' {1}
```

To use EPS from Stata and convert the image to `png` (in this case using `imagemagick`'s `convert` program).