### PR TITLE
Add environmental variable option for config global and user locations

### DIFF
--- a/docs/src/using_stata_kernel/configuration.md
+++ b/docs/src/using_stata_kernel/configuration.md
@@ -24,7 +24,7 @@ If you want these changes to be stored permanently, add `--permanently`:
 
 !!! info "System wide configuration file for JupyterHub"
 
-    If you are installign `stata_kernel` in Jupyter Hub you must create a system
+    If you are installing `stata_kernel` in Jupyter Hub you must create a system
     wide configuration file to provide default values. The default location
     is in `/etc/stata_kernel.conf`, or defined by the environmental variable
     `STATA_KERNEL_GLOBAL_CONFIG_PATH`.

--- a/docs/src/using_stata_kernel/configuration.md
+++ b/docs/src/using_stata_kernel/configuration.md
@@ -1,7 +1,9 @@
 # Configuration
 
 The configuration file is a plain text file named `.stata_kernel.conf` and is
-located in your home directory. You can change any of the package's settings by
+located in your home directory, or defined by the environmental variable
+`STATA_KERNEL_USER_CONFIG_PATH`. Settings must be under the heading
+`[stata_kernel]`. You can change any of the package's settings by
 opening the file and changing the `value` of any line of the form
 
 ```
@@ -23,8 +25,9 @@ If you want these changes to be stored permanently, add `--permanently`:
 !!! info "System wide configuration file for JupyterHub"
 
     If you are installign `stata_kernel` in Jupyter Hub you must create a system
-    wide configuration file in `/etc/stata_kernel.conf` to provide default
-    values.
+    wide configuration file to provide default values. The default location
+    is in `/etc/stata_kernel.conf`, or defined by the environmental variable
+    `STATA_KERNEL_GLOBAL_CONFIG_PATH`.
 
 ## General settings
 
@@ -130,3 +133,18 @@ For more information about what _Graph Redundancy_ is, [read here](intro.md#grap
 
 Whether to provide redundant PDF images when `png` is the display format. `False` by default.
 For more information about what _Graph Redundancy_ is, [read here](intro.md#graph-redundancy).
+
+## Example config file
+
+An example config file:
+
+``` ini
+[stata_kernel]
+stata_path = "C:\Program Files\Stata16\StataMP-64.exe"
+execution_mode = automation
+cache_directory = ~/.stata_kernel_cache
+autocomplete_closing_symbol = False
+graph_format = svg
+graph_scale = 1
+user_graph_keywords = coefplot,vioplot
+```

--- a/stata_kernel/config.py
+++ b/stata_kernel/config.py
@@ -51,7 +51,7 @@ class Config():
         Example config file::
 
             [stata_kernel]
-            stata_path = "C:\Program Files\Stata16\StataMP-64.exe"
+            stata_path = "C:/Program Files/Stata16/StataMP-64.exe"
             execution_mode = automation
             cache_directory = ~/.stata_kernel_cache
             autocomplete_closing_symbol = False

--- a/stata_kernel/config.py
+++ b/stata_kernel/config.py
@@ -1,3 +1,4 @@
+import os
 import re
 import platform
 
@@ -8,6 +9,10 @@ from configparser import ConfigParser, NoSectionError
 from .utils import find_path
 
 GLOBAL_PATH = '/etc/stata_kernel.conf'
+USER_PATH = '~/.stata_kernel.conf'
+
+GLOBAL_PATH_ENVVAR_NAME = 'STATA_KERNEL_GLOBAL_CONFIG_PATH'
+USER_PATH_ENVVAR_NAME = 'STATA_KERNEL_USER_CONFIG_PATH'
 
 
 class Config():
@@ -27,24 +32,40 @@ class Config():
 
     def __init__(self):
         """
-        Load config both from a potential system-wide config file and from a
+        Load config both from a potential system-wide config file or from a
         user-defined one if present.
 
         We first load from the system-wide location if the file is present and
         then we load the user-defined location, updating entries. Thus the
         user-location takes precedence, but either file can be missing.
 
+        The user-defined path defaults to `~/.stata_kernel.conf` or can be read
+        from the environmental variable `STATA_KERNEL_USER_CONFIG_PATH`.
+
         The system-wide config file was added to facilitate deployments on
-        systems like Jupyter Hub; it must be created in `/etc/stata_kernel.conf`
+        systems like Jupyter Hub; it defaults to `/etc/stata_kernel.conf` or
+        read from the environmental variable `STATA_KERNEL_GLOBAL_CONFIG_PATH`,
         and we do not otherwise keep a reference to it because it is likely
         non-writable. Setting any config option should go to the user-config.
+
+        Example config file::
+
+            [stata_kernel]
+            stata_path = "C:\Program Files\Stata16\StataMP-64.exe"
+            execution_mode = automation
+            cache_directory = ~/.stata_kernel_cache
+            autocomplete_closing_symbol = False
+            graph_format = svg
+            graph_scale = 1
+            user_graph_keywords = coefplot,vioplot
         """
+        _global_path = os.environ.get(GLOBAL_PATH_ENVVAR_NAME, GLOBAL_PATH)
+        _user_path = os.environ.get(USER_PATH_ENVVAR_NAME, USER_PATH)
 
         global_config = ConfigParser()
-        global_config.read(str(GLOBAL_PATH))
+        global_config.read(_global_path)
 
-
-        self.config_path = Path('~/.stata_kernel.conf').expanduser()
+        self.config_path = Path(_user_path).expanduser()
         self.config = ConfigParser()
         self.config.read(str(self.config_path))
 


### PR DESCRIPTION
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] Add environmental variable option for specifying config file location:
   - [x] Global config path can come from `STATA_KERNEL_GLOBAL_CONFIG_PATH`
   - [x] User config path can come from `STATA_KERNEL_USER_CONFIG_PATH`
- [x] Update documentation to reflect these changes
- [x] Add example config to end of documentation Configuration page.
   - [x] closes #347 

Example:

``` bash
$ STATA_KERNEL_USER_CONFIG_PATH=/opt/python/share/source/stata_kernel/.stata_kernel.conf python -c "from stata_kernel.config import config;print('config_path:', config.config_path, '\nstata_path:', config.get('stata_path'))"
config_path: /opt/python/share/source/stata_kernel/.stata_kernel.conf
stata_path: /opt/stata/stata