### PR TITLE
Fix install on linux when can't find stata path

### DIFF
--- a/stata_kernel/__init__.py
+++ b/stata_kernel/__init__.py
@@ -2,4 +2,7 @@
 
 __version__ = '1.12.0'
 
-from .kernel import StataKernel
+try:
+    from .kernel import StataKernel
+except:
+    print('Cannot import kernel')

--- a/stata_kernel/install.py
+++ b/stata_kernel/install.py
@@ -47,8 +47,6 @@ def install_conf(conf_file):
         execution_mode = 'console'
 
     stata_path = find_path()
-    if 'IC.app' in stata_path:
-        execution_mode = 'automation'
     if not stata_path:
         msg = """\
             WARNING: Could not find Stata path.
@@ -58,6 +56,8 @@ def install_conf(conf_file):
 
             """
         print(dedent(msg))
+    elif 'IC.app' in stata_path:
+        execution_mode = 'automation'
 
     conf_default = dedent(
         """\


### PR DESCRIPTION
Closes #362

Traceback when trying to install on an ubuntu machine without Stata:

```
> python -m stata_kernel.install
Traceback (most recent call last):
  File "/home/ubuntu/local/miniconda3/lib/python3.8/runpy.py", line 185, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/home/ubuntu/local/miniconda3/lib/python3.8/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "/home/ubuntu/local/miniconda3/lib/python3.8/site-packages/stata_kernel/__init__.py", line 5, in <module>
    from .kernel import StataKernel
  File "/home/ubuntu/local/miniconda3/lib/python3.8/site-packages/stata_kernel/kernel.py", line 16, in <module>
    from .config import config
  File "/home/ubuntu/local/miniconda3/lib/python3.8/site-packages/stata_kernel/config.py", line 171, in <module>
    config = Config()
  File "/home/ubuntu/local/miniconda3/lib/python3.8/site-packages/stata_kernel/config.py", line 86, in __init__
    self.raise_config_error('stata_path')
  File "/home/ubuntu/local/miniconda3/lib/python3.8/site-packages/stata_kernel/config.py", line 161, in raise_config_error
    raise ValueError(dedent(msg))
ValueError: stata_path option in configuration file is missing or invalid
Refer to the documentation to see how to set it manually:

https://kylebarron.dev/stata_kernel/using_stata_kernel/configuration/
```

and `~/.stata_kernel.conf` isn't created. It looks like importing the kernel fails because of a bug in the config.