### PR TITLE
Removed jupyter from requirements, modified docs

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -33,7 +33,14 @@ conda install -c conda-forge stata_kernel
 python -m stata_kernel.install
 ```
 
-Otherwise, from a terminal or command prompt run:
+If Python 2 is the default ersion of Python on your system, you may need to use
+
+```bash
+conda install -c conda-forge stata_kernel
+python3 -m stata_kernel.install
+```
+
+If you do not use Anaconda/Miniconda, from a terminal or command prompt run:
 
 ```bash
 pip install stata_kernel

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -26,7 +26,14 @@ It doesn't take much to get `stata_kernel` up and running. Here's how:
 
 ## Package Install
 
-To install the kernel, from a terminal or command prompt run:
+If you use Anaconda or Miniconda, from the Anaconda Prompt run:
+
+```bash
+conda install -c conda-forge stata_kernel
+python -m stata_kernel.install
+```
+
+Otherwise, from a terminal or command prompt run:
 
 ```bash
 pip install stata_kernel
@@ -37,6 +44,24 @@ If Python 2 is the default version of Python on your system, you may need to use
 ```bash
 pip3 install stata_kernel
 python3 -m stata_kernel.install
+```
+
+### Jupyter
+
+If you chose to install Anaconda you already have Jupyter and Jupyter Lab installed.
+
+If you downloaded Miniconda, you need to install Jupyter and optionally Jupyter Lab:
+
+```bash
+conda install jupyter
+conda install jupyterlab
+```
+
+Otherwise you can install them using `pip`:
+
+```bash
+pip install jupyter
+pip install jupyterlab
 ```
 
 In order to get syntax highlighting in Jupyter Lab, run:
@@ -51,9 +76,15 @@ If you didn't install Python from Anaconda, the `conda` command won't work and y
 
 To upgrade from a previous version of `stata_kernel`, from a terminal or command prompt run
 
+```bash
+conda update stata_kernel -y
 ```
+in the case of Anaconda/Miniconda or
+
+```bash
 pip install stata_kernel --upgrade
 ```
+otherwise.
 
 When upgrading, you don't have to run `python -m stata_kernel.install` again.
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -48,21 +48,35 @@ python3 -m stata_kernel.install
 
 ### Jupyter
 
-If you chose to install Anaconda you already have Jupyter and Jupyter Lab installed.
+If you chose to install Anaconda you already have [Jupyter Notebook](https://jupyter-notebook.readthedocs.io/en/stable/notebook.html) and [Jupyter Lab](https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html) installed.
 
-If you downloaded Miniconda, you need to install Jupyter and optionally Jupyter Lab:
+Otherwise, you need to install Jupyter Notebook or Jupyter Lab. I recommend the latter as it is a similar but more modern environment. If you have Miniconda, open the Anaconda Prompt and run:
 
 ```bash
-conda install jupyter
 conda install jupyterlab
 ```
 
-Otherwise you can install them using `pip`:
+If you use pip, you can install it via:
 
 ```bash
-pip install jupyter
-pip install jupyterlab
+pip install jupyterlab 
+pip3 install jupyterlab  # if Python 2 is the default version
 ```
+
+If you would not like to install Jupyter Lab and only need the Notebook, you can install it by running
+
+```bash
+conda install notebook
+```
+
+or
+
+```bash
+pip install notebook
+pip3 install notebook  # if Python 2 is the default version
+```
+
+depending on your package manager.
 
 In order to get syntax highlighting in Jupyter Lab, run:
 ```bash
@@ -70,7 +84,7 @@ conda install -c conda-forge nodejs -y
 jupyter labextension install jupyterlab-stata-highlight
 ```
 
-If you didn't install Python from Anaconda, the `conda` command won't work and you'll need to install [Node.js](https://nodejs.org/en/download/) directly before running `jupyter labextension install`.
+If you didn't install Python from Anaconda/Miniconda, the `conda` command won't work and you'll need to install [Node.js](https://nodejs.org/en/download/) directly before running `jupyter labextension install`.
 
 ### Upgrading
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 beautifulsoup4>=4.6.3
-jupyter>=1.0.0
 jupyter_client>=5.2.3
 IPython>=6.5.0
 ipykernel>=4.8.2

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open('requirements_dev.txt') as test_requirements_file:
     test_requirements = test_requirements_file.readlines()
     test_requirements = [x[:-1] for x in test_requirements]
 
-setup_requirements = ['setuptools >= 38.6.0', 'twine >= 1.11.0']
+setup_requirements = ['setuptools >= 38.6.0']
 
 # Recompile included docs
 if platform.system() != 'Windows':


### PR DESCRIPTION
- [x] closes #361 
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Added instructions to the docs for installing jupyter notebook/lab.

The conda-forge package should be up soon (waiting for the review from the conda-forge team), so also added instructions to install stata_kernel via conda.

The same tests fail as before the change:
test_kernel_display_data.py::StataKernelTestFramework::test_kernel_info - AttributeError: 'NoneType' obj...
test_kernel_stdout.py::TestKernelStdout::test_stata_more - AssertionError: 0 not greater than or equal to 1
test_kernel_stdout.py::StataKernelTestFramework::test_kernel_info - AttributeError: 'NoneType' object ha...