### PR TITLE
Fixes #370: File spaces in cache dir for graph export

### DIFF
--- a/stata_kernel/code_manager.py
+++ b/stata_kernel/code_manager.py
@@ -295,15 +295,15 @@ class CodeManager():
         if not pdf_dup:
             g_exp = dedent("""
             if _rc == 0 {{
-                noi gr export {0}/graph${1}.{2},{3} replace
+                noi gr export `"{0}/graph${1}.{2}"',{3} replace
                 global {1} = ${1} + 1
             }}\
             """.format(cache_dir_str, gph_cnt, graph_fmt, dim_str))
         else:
             g_exp = dedent("""
             if _rc == 0 {{
-                noi gr export {0}/graph${1}.{2},{3} replace
-                noi gr export {0}/graph${1}.pdf, replace
+                noi gr export `"{0}/graph${1}.{2}"',{3} replace
+                noi gr export `"{0}/graph${1}.pdf"', replace
                 global {1} = ${1} + 1
             }}\
             """.format(cache_dir_str, gph_cnt, graph_fmt, dim_str))


### PR DESCRIPTION
- [X] closes #371
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Just to double-check the change makes sense. Basically the same as #369.