### PR TITLE
Added stack trace to kernel import

### DIFF
--- a/stata_kernel/__init__.py
+++ b/stata_kernel/__init__.py
@@ -1,8 +1,11 @@
 """An example Jupyter kernel"""
 
+import traceback
+
 __version__ = '1.12.1'
 
 try:
     from .kernel import StataKernel
 except:
     print('Cannot import kernel')
+    traceback.print_exc()


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

The title. I think the full traceback when debugging might be better than the error message.

Flake complains about bare "except" and importing the kernel but not using it, btw.