### PR TITLE
Simplify kernel installation for conda packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [XXX] - 2021-02-25
+## [1.12.3] - 2021-02-25
 
 - Simplify kernel installation for conda environments
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [XXX] - 2021-02-25
+
+- Simplify kernel installation for conda environments
+
 ## [1.12.2] - 2020-11-30
 
 - File spaces in cache dir for graph export (#371)

--- a/stata_kernel/__init__.py
+++ b/stata_kernel/__init__.py
@@ -3,9 +3,3 @@
 import traceback
 
 __version__ = '1.12.2'
-
-try:
-    from .kernel import StataKernel
-except:
-    print('Cannot import kernel')
-    traceback.print_exc()

--- a/stata_kernel/__init__.py
+++ b/stata_kernel/__init__.py
@@ -1,5 +1,3 @@
 """An example Jupyter kernel"""
 
-import traceback
-
 __version__ = '1.12.2'

--- a/stata_kernel/__init__.py
+++ b/stata_kernel/__init__.py
@@ -1,3 +1,3 @@
 """An example Jupyter kernel"""
 
-__version__ = '1.12.2'
+__version__ = '1.12.3'

--- a/stata_kernel/__main__.py
+++ b/stata_kernel/__main__.py
@@ -1,4 +1,10 @@
 from ipykernel.kernelapp import IPKernelApp
-from .kernel import StataKernel
+
+import traceback
+try:
+    from .kernel import StataKernel
+except:
+    print('Cannot import kernel')
+    traceback.print_exc()
 
 IPKernelApp.launch_instance(kernel_class=StataKernel)

--- a/stata_kernel/__main__.py
+++ b/stata_kernel/__main__.py
@@ -1,4 +1,4 @@
 from ipykernel.kernelapp import IPKernelApp
-from . import StataKernel
+from .kernel import StataKernel
 
 IPKernelApp.launch_instance(kernel_class=StataKernel)

--- a/stata_kernel/install.py
+++ b/stata_kernel/install.py
@@ -13,7 +13,8 @@ from jupyter_client.kernelspec import KernelSpecManager
 
 
 kernel_json = {
-    "argv": [sys.executable, "-m", "stata_kernel.kernel", "-f", "{connection_file}"],
+    "argv": [sys.executable, "-m", "stata_kernel.kernel",
+             "-f", "{connection_file}"],
     "display_name": "Stata",
     "language": "stata", }
 

--- a/stata_kernel/install.py
+++ b/stata_kernel/install.py
@@ -11,10 +11,9 @@ from pkg_resources import resource_filename
 from IPython.utils.tempdir import TemporaryDirectory
 from jupyter_client.kernelspec import KernelSpecManager
 
-from .utils import find_path
 
 kernel_json = {
-    "argv": [sys.executable, "-m", "stata_kernel", "-f", "{connection_file}"],
+    "argv": [sys.executable, "-m", "stata_kernel.kernel", "-f", "{connection_file}"],
     "display_name": "Stata",
     "language": "stata", }
 
@@ -46,6 +45,10 @@ def install_conf(conf_file):
     else:
         execution_mode = 'console'
 
+    # By avoiding an import of .utils until we need it, we can
+    # complete the installation process in virtual environments
+    # without needing this submodule nor its downstream imports.
+    from .utils import find_path
     stata_path = find_path()
     if not stata_path:
         msg = """\
@@ -113,6 +116,9 @@ def main(argv=None):
     ap.add_argument(
         '--prefix', help="Install to the given prefix. "
         "Kernelspec will be installed in {PREFIX}/share/jupyter/kernels/")
+    ap.add_argument(
+        '--no-conf-file', action='store_true',
+        help="Skip the creation of a default user configuration file.")
     args = ap.parse_args(argv)
 
     if args.sys_prefix:
@@ -121,9 +127,10 @@ def main(argv=None):
         args.user = True
 
     install_my_kernel_spec(user=args.user, prefix=args.prefix)
-    conf_file = Path('~/.stata_kernel.conf').expanduser()
-    if not conf_file.is_file():
-        install_conf(conf_file)
+    if not args.no_conf_file:
+        conf_file = Path('~/.stata_kernel.conf').expanduser()
+        if not conf_file.is_file():
+            install_conf(conf_file)
 
 
 if __name__ == '__main__':

--- a/stata_kernel/install.py
+++ b/stata_kernel/install.py
@@ -13,8 +13,7 @@ from jupyter_client.kernelspec import KernelSpecManager
 
 
 kernel_json = {
-    "argv": [sys.executable, "-m", "stata_kernel.kernel",
-             "-f", "{connection_file}"],
+    "argv": [sys.executable, "-m", "stata_kernel", "-f", "{connection_file}"],
     "display_name": "Stata",
     "language": "stata", }
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

The conda package for `stata_kernel` offered by conda-forge requires a manual step following installation. This is, in theory, not necessary. It should be possible to do something like `python -m stata_kernel.install --sys-prefix` within the conda recipe itself, so that the kernel specification is included within the tarball. Other kernels successfully do this.

I believe this PR will accomplish this for the Stata kernel. To accomplish this, we've done a couple of things:
- Remove the `from . import kernel` from `__init__.py`. This allows the conda recipe to complete the packaging without importing the entirety of the `stata_kernel` dependency set. Of course, this also means that the `kernel.json` file has to call `stata_kernel.kernel` directly instead of just `stata_kernel`.
- Modify the installation process to reduce its import requirements as well. To accomplish this, I added a new installation flag `--no-conf-file` that skips the creation of the conf file, and thereby bypassing even the need to look for a Stata binary.
