### PR TITLE
Fixes #389; copyright no longer wrapped in a tag

### DIFF
--- a/stata_kernel/stata_magics.py
+++ b/stata_kernel/stata_magics.py
@@ -630,7 +630,12 @@ class StataMagics():
             soup.find('div', id='menu').decompose()
 
             # Remove Copyright notice
-            soup.find('a', text='Copyright').find_parent("table").decompose()
+            tags = ['a', 'font']
+            for tag in tags:
+                copyright = soup.find(tag, text='Copyright')
+                if copyright:
+                    copyright.find_parent("table").decompose()
+                    break
 
             # Remove last hrule
             soup.find_all('hr')[-1].decompose()


### PR DESCRIPTION
- [X] closes #389
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Should be a straightforward fix.