### PR TITLE
Use exactly one kernel_cache_dir and config object per kernel instance

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,7 @@
 bumpversion==0.5.3
 coverage==4.5.1
 flake8==3.5.0
+importlib-metadata==0.23
 jupyter_kernel_test==0.3.0
 mkdocs-material==3.0.3
 mkdocs==1.0

--- a/stata_kernel/config.py
+++ b/stata_kernel/config.py
@@ -109,6 +109,10 @@ class Config():
         return self.env.get(key, backup)
 
     def set(self, key, val, permanent=False):
+        if key.startswith('cache_dir'):
+            val = Path(val).expanduser()
+            val.mkdir(parents=True, exist_ok=True)
+
         self.env[key] = val
 
         if permanent:

--- a/stata_kernel/config.py
+++ b/stata_kernel/config.py
@@ -4,6 +4,7 @@ import platform
 
 from pathlib import Path
 from textwrap import dedent
+from tempfile import TemporaryDirectory
 from configparser import ConfigParser, NoSectionError
 
 from .utils import find_path
@@ -77,9 +78,11 @@ class Config():
             except NoSectionError:
                 pass
 
-        cache_dir = Path(self.get('cache_directory',
-                                  '~/.stata_kernel_cache')).expanduser()
-        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_par_dir = Path(self.get('cache_directory',
+                                      '~/.stata_kernel_cache')).expanduser()
+        cache_par_dir.mkdir(parents=True, exist_ok=True)
+        self._cache_temp_dir = TemporaryDirectory(dir=str(cache_par_dir))
+        cache_dir = Path(self._cache_temp_dir.name)
 
         stata_path = self.get('stata_path', find_path())
         if not stata_path:
@@ -106,10 +109,6 @@ class Config():
         return self.env.get(key, backup)
 
     def set(self, key, val, permanent=False):
-        if key.startswith('cache_dir'):
-            val = Path(val).expanduser()
-            val.mkdir(parents=True, exist_ok=True)
-
         self.env[key] = val
 
         if permanent:


### PR DESCRIPTION
- [x] closes #405
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

whatsnew entry:
* fix intermittent Stata errors when running simultaneous sessions (#405)