### PR TITLE
Dev graph match fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.12.2
+current_version = 1.12.3
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.12.3
+current_version = 1.13.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/kylebarron/stata_kernel',
-    version='1.12.3',
+    version='1.13.0',
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/kylebarron/stata_kernel',
-    version='1.12.2',
+    version='1.12.3',
     include_package_data=True
 )

--- a/stata_kernel/__init__.py
+++ b/stata_kernel/__init__.py
@@ -1,3 +1,3 @@
 """An example Jupyter kernel"""
 
-__version__ = '1.12.3'
+__version__ = '1.13.0'

--- a/stata_kernel/kernel.py
+++ b/stata_kernel/kernel.py
@@ -22,7 +22,7 @@ from .stata_magics import StataMagics
 
 class StataKernel(Kernel):
     implementation = 'stata_kernel'
-    implementation_version = '1.12.3'
+    implementation_version = '1.13.0'
     language = 'stata'
     language_info = {
         'name': 'stata',

--- a/stata_kernel/kernel.py
+++ b/stata_kernel/kernel.py
@@ -22,7 +22,7 @@ from .stata_magics import StataMagics
 
 class StataKernel(Kernel):
     implementation = 'stata_kernel'
-    implementation_version = '1.12.2'
+    implementation_version = '1.12.3'
     language = 'stata'
     language_info = {
         'name': 'stata',


### PR DESCRIPTION
- [X] closes #415
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

@kylebarron Just tagging you in case you know how to make `pexpect` match the parenthesis when you pass `\(?` to the regex. Otherwise I'll keep my ad-hoc fix of manually adding the parenthesis; seems clunky but it works.