### PR TITLE
Check for the existence of configuration file

### DIFF
--- a/stata_kernel/config.py
+++ b/stata_kernel/config.py
@@ -63,6 +63,9 @@ class Config():
         _global_path = os.environ.get(GLOBAL_PATH_ENVVAR_NAME, GLOBAL_PATH)
         _user_path = os.environ.get(USER_PATH_ENVVAR_NAME, USER_PATH)
 
+        if not os.path.isfile(_user_path):
+            raise Exception(f"Configuration file {_user_path} does not exist")
+
         global_config = ConfigParser()
         global_config.read(_global_path)
 


### PR DESCRIPTION
If the configuration file does not exist, currently the error message says that `stata_path` in configuration file is undefined.

This prints a better error message.